### PR TITLE
Add HTTP/2, QUIC, VPN and Self-Signed CA support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
-    
+
     <queries>
       <!-- If your app opens https URLs -->
       <intent>
@@ -37,7 +37,8 @@
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/lib/boorus/anime-pictures/providers.dart
+++ b/lib/boorus/anime-pictures/providers.dart
@@ -10,13 +10,12 @@ import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/downloads/downloads.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/tags/tags.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'anime_pictures.dart';
 
 final animePicturesClientProvider =
     Provider.family<AnimePicturesClient, BooruConfig>(
   (ref, config) {
-    final dio = newDio(ref.watch(dioArgsProvider(config)));
+    final dio = ref.watch(dioProvider(config));
 
     return AnimePicturesClient(
       dio: dio,

--- a/lib/boorus/danbooru/danbooru_provider.dart
+++ b/lib/boorus/danbooru/danbooru_provider.dart
@@ -9,12 +9,11 @@ import 'package:boorusama/core/autocompletes/autocompletes.dart';
 import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/tags/tags.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/functional.dart';
 
 final danbooruClientProvider =
     Provider.family<DanbooruClient, BooruConfig>((ref, booruConfig) {
-  final dio = newDio(ref.watch(dioArgsProvider(booruConfig)));
+  final dio = ref.watch(dioProvider(booruConfig));
 
   return DanbooruClient(
     dio: dio,

--- a/lib/boorus/danbooru/users/users_provider.dart
+++ b/lib/boorus/danbooru/users/users_provider.dart
@@ -11,7 +11,6 @@ import 'package:boorusama/boorus/providers.dart';
 import 'package:boorusama/clients/danbooru/danbooru_client.dart';
 import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/posts/posts.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/functional.dart';
 
 final danbooruUserRepoProvider =
@@ -37,7 +36,7 @@ final danbooruCurrentUserProvider =
 
   // If the cached id is null, we need to fetch it from the api
   if (id == null) {
-    final dio = newDio(ref.watch(dioArgsProvider(config)));
+    final dio = ref.watch(dioProvider(config));
 
     final data = await DanbooruClient(
             dio: dio,

--- a/lib/boorus/e621/e621.dart
+++ b/lib/boorus/e621/e621.dart
@@ -14,7 +14,6 @@ import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/configs/create/create.dart';
 import 'package:boorusama/core/downloads/downloads.dart';
 import 'package:boorusama/core/posts/posts.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'artists/artists.dart';
 import 'comments/comments.dart';
 import 'favorites/favorites.dart';
@@ -24,7 +23,7 @@ import 'tags/tags.dart';
 
 final e621ClientProvider =
     Provider.family<E621Client, BooruConfig>((ref, booruConfig) {
-  final dio = newDio(ref.watch(dioArgsProvider(booruConfig)));
+  final dio = ref.watch(dioProvider(booruConfig));
 
   return E621Client(
     baseUrl: booruConfig.url,

--- a/lib/boorus/gelbooru/gelbooru.dart
+++ b/lib/boorus/gelbooru/gelbooru.dart
@@ -21,7 +21,6 @@ import 'package:boorusama/core/notes/notes.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/scaffolds/scaffolds.dart';
 import 'package:boorusama/core/tags/tags.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'artists/gelbooru_artist_page.dart';
 import 'comments/gelbooru_comment_page.dart';
 import 'configs/create_gelbooru_config_page.dart';
@@ -38,7 +37,7 @@ String getGelbooruProfileUrl(String url) => url.endsWith('/')
 
 final gelbooruClientProvider =
     Provider.family<GelbooruClient, BooruConfig>((ref, booruConfig) {
-  final dio = newDio(ref.watch(dioArgsProvider(booruConfig)));
+  final dio = ref.watch(dioProvider(booruConfig));
 
   return GelbooruClient.custom(
     baseUrl: booruConfig.url,

--- a/lib/boorus/gelbooru_v1/gelbooru_v1.dart
+++ b/lib/boorus/gelbooru_v1/gelbooru_v1.dart
@@ -20,7 +20,6 @@ import 'package:boorusama/core/downloads/downloads.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/scaffolds/scaffolds.dart';
 import 'package:boorusama/foundation/html.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/widgets/info_container.dart';
 
 part 'providers.dart';

--- a/lib/boorus/gelbooru_v1/providers.dart
+++ b/lib/boorus/gelbooru_v1/providers.dart
@@ -73,7 +73,7 @@ final gelbooruV1AutocompleteRepoProvider =
 
 final gelbooruV1ClientProvider =
     Provider.family<GelbooruV1Client, BooruConfig>((ref, booruConfig) {
-  final dio = newDio(ref.watch(dioArgsProvider(booruConfig)));
+  final dio = ref.watch(dioProvider(booruConfig));
 
   return GelbooruV1Client(
     baseUrl: booruConfig.url,

--- a/lib/boorus/gelbooru_v2/gelbooru_v2.dart
+++ b/lib/boorus/gelbooru_v2/gelbooru_v2.dart
@@ -21,7 +21,6 @@ import 'package:boorusama/core/notes/notes.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/scaffolds/scaffolds.dart';
 import 'package:boorusama/core/tags/tags.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'create_gelbooru_v2_config_page.dart';
 import 'home/gelbooru_v2_home_page.dart';
 import 'posts/gelbooru_v2_post_details_page.dart';
@@ -31,7 +30,7 @@ const kGelbooruV2CustomDownloadFileNameFormat =
 
 final gelbooruV2ClientProvider =
     Provider.family<GelbooruV2Client, BooruConfig>((ref, booruConfig) {
-  final dio = newDio(ref.watch(dioArgsProvider(booruConfig)));
+  final dio = ref.watch(dioProvider(booruConfig));
 
   return GelbooruV2Client.custom(
     baseUrl: booruConfig.url,

--- a/lib/boorus/hydrus/hydrus.dart
+++ b/lib/boorus/hydrus/hydrus.dart
@@ -21,7 +21,6 @@ import 'package:boorusama/core/home/home.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/scaffolds/scaffolds.dart';
 import 'package:boorusama/foundation/i18n.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/router.dart';
 import 'package:boorusama/widgets/widgets.dart';
 import 'favorites/favorites.dart';
@@ -65,7 +64,7 @@ class HydrusPost extends SimplePost {
 
 final hydrusClientProvider =
     Provider.family<HydrusClient, BooruConfig>((ref, config) {
-  final dio = newDio(ref.watch(dioArgsProvider(config)));
+  final dio = ref.watch(dioProvider(config));
 
   return HydrusClient(
     dio: dio,

--- a/lib/boorus/moebooru/moebooru.dart
+++ b/lib/boorus/moebooru/moebooru.dart
@@ -16,7 +16,6 @@ import 'package:boorusama/core/downloads/downloads.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/scaffolds/scaffolds.dart';
 import 'package:boorusama/core/tags/tags.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/functional.dart';
 import 'configs/create_moebooru_config_page.dart';
 import 'feats/posts/posts.dart';
@@ -29,7 +28,7 @@ import 'pages/widgets/moebooru_related_post_section.dart';
 
 final moebooruClientProvider =
     Provider.family<MoebooruClient, BooruConfig>((ref, booruConfig) {
-  final dio = newDio(ref.watch(dioArgsProvider(booruConfig)));
+  final dio = ref.watch(dioProvider(booruConfig));
 
   return MoebooruClient.custom(
     baseUrl: booruConfig.url,

--- a/lib/boorus/philomena/providers.dart
+++ b/lib/boorus/philomena/providers.dart
@@ -9,12 +9,11 @@ import 'package:boorusama/clients/philomena/types/image_dto.dart';
 import 'package:boorusama/core/autocompletes/autocompletes.dart';
 import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/posts/posts.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/functional.dart';
 
 final philomenaClientProvider = Provider.family<PhilomenaClient, BooruConfig>(
   (ref, config) {
-    final dio = newDio(ref.watch(dioArgsProvider(config)));
+    final dio = ref.watch(dioProvider(config));
 
     return PhilomenaClient(
       dio: dio,

--- a/lib/boorus/providers.dart
+++ b/lib/boorus/providers.dart
@@ -2,6 +2,7 @@
 import 'dart:io';
 
 // Package imports:
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
@@ -234,20 +235,20 @@ class DioArgs {
   final BooruFactory booruFactory;
 }
 
-final dioArgsProvider = Provider.family<DioArgs, BooruConfig>((ref, config) {
+final dioProvider = Provider.family<Dio, BooruConfig>((ref, config) {
   final cacheDir = ref.watch(httpCacheDirProvider);
   final userAgentGenerator = ref.watch(userAgentGeneratorProvider(config));
   final loggerService = ref.watch(loggerProvider);
   final booruFactory = ref.watch(booruFactoryProvider);
 
-  return DioArgs(
+  return newDio(DioArgs(
     cacheDir: cacheDir,
     baseUrl: config.url,
     userAgentGenerator: userAgentGenerator,
     booruConfig: config,
     loggerService: loggerService,
     booruFactory: booruFactory,
-  );
+  ));
 });
 
 final httpCacheDirProvider = Provider<Directory>(
@@ -492,7 +493,7 @@ final blacklistTagsProvider =
 
 final booruSiteValidatorProvider =
     FutureProvider.autoDispose.family<bool, BooruConfig>((ref, config) {
-  final dio = newDio(ref.watch(dioArgsProvider(config)));
+  final dio = ref.watch(dioProvider(config));
   final login =
       config.login.toOption().fold(() => null, (v) => v.isEmpty ? null : v);
   final apiKey =

--- a/lib/boorus/sankaku/sankaku.dart
+++ b/lib/boorus/sankaku/sankaku.dart
@@ -21,7 +21,6 @@ import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/scaffolds/artist_page_scaffold.dart';
 import 'package:boorusama/core/tags/tags.dart';
 import 'package:boorusama/foundation/caching/caching.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/router.dart';
 import 'sankaku_post.dart';
 

--- a/lib/boorus/sankaku/sankaku_provider.dart
+++ b/lib/boorus/sankaku/sankaku_provider.dart
@@ -2,7 +2,7 @@ part of 'sankaku.dart';
 
 final sankakuClientProvider = Provider.family<SankakuClient, BooruConfig>(
   (ref, config) {
-    final dio = newDio(ref.watch(dioArgsProvider(config)));
+    final dio = ref.watch(dioProvider(config));
     final booruFactory = ref.watch(booruFactoryProvider);
     final booru = booruFactory.create(type: config.booruType);
 

--- a/lib/boorus/shimmie2/providers.dart
+++ b/lib/boorus/shimmie2/providers.dart
@@ -7,12 +7,11 @@ import 'package:boorusama/clients/shimmie2/shimmie2_client.dart';
 import 'package:boorusama/core/autocompletes/autocompletes.dart';
 import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/posts/posts.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/foundation/path.dart';
 
 final shimmie2ClientProvider = Provider.family<Shimmie2Client, BooruConfig>(
   (ref, config) {
-    final dio = newDio(ref.watch(dioArgsProvider(config)));
+    final dio = ref.watch(dioProvider(config));
 
     return Shimmie2Client(
       dio: dio,

--- a/lib/boorus/szurubooru/providers.dart
+++ b/lib/boorus/szurubooru/providers.dart
@@ -11,7 +11,6 @@ import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/tags/tags.dart';
 import 'package:boorusama/dart.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/foundation/path.dart';
 import 'package:boorusama/functional.dart';
 import 'post_votes/post_votes.dart';
@@ -19,7 +18,7 @@ import 'szurubooru_post.dart';
 
 final szurubooruClientProvider = Provider.family<SzurubooruClient, BooruConfig>(
   (ref, config) {
-    final dio = newDio(ref.watch(dioArgsProvider(config)));
+    final dio = ref.watch(dioProvider(config));
 
     return SzurubooruClient(
       dio: dio,

--- a/lib/boorus/zerochan/providers.dart
+++ b/lib/boorus/zerochan/providers.dart
@@ -9,13 +9,12 @@ import 'package:boorusama/core/autocompletes/autocompletes.dart';
 import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/core/tags/tags.dart';
-import 'package:boorusama/foundation/networking/networking.dart';
 import 'package:boorusama/foundation/path.dart' as path;
 import 'zerochan_post.dart';
 
 final zerochanClientProvider =
     Provider.family<ZerochanClient, BooruConfig>((ref, config) {
-  final dio = newDio(ref.watch(dioArgsProvider(config)));
+  final dio = ref.watch(dioProvider(config));
   final logger = ref.watch(loggerProvider);
 
   return ZerochanClient(

--- a/lib/core/comments/youtube_preview_box.dart
+++ b/lib/core/comments/youtube_preview_box.dart
@@ -4,11 +4,11 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:dio/dio.dart';
-import 'package:extended_image/extended_image.dart';
 import 'package:html/parser.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 // Project imports:
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
 import 'package:boorusama/foundation/theme.dart';
 import 'package:boorusama/foundation/url_launcher.dart';
@@ -24,8 +24,9 @@ class YoutubePreviewBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     try {
+      final dio = Dio();
       return FutureBuilder<PreviewUrlData>(
-        future: Dio()
+        future: dio
             .getUri(uri)
             .then((value) => value.data)
             .then((value) => parseHtmlAsync(value, uri.toString())),
@@ -60,8 +61,9 @@ class YoutubePreviewBox extends StatelessWidget {
                             ClipRRect(
                               borderRadius:
                                   const BorderRadius.all(Radius.circular(8)),
-                              child: ExtendedImage.network(
+                              child: DioExtendedImage.network(
                                 data.previewImage!,
+                                dio: dio,
                                 fit: BoxFit.contain,
                                 cacheMaxAge: kDefaultImageCacheDuration,
                               ),

--- a/lib/core/configs/booru_factory.dart
+++ b/lib/core/configs/booru_factory.dart
@@ -29,6 +29,8 @@ class BooruFactory {
     return null;
   }
 
+  Booru? getBooruFromId(int id) => boorus.firstWhereOrNull((e) => e.id == id);
+
   Booru? create({
     required BooruType type,
   }) {
@@ -49,6 +51,6 @@ class BooruFactory {
       BooruType.unknown => 0,
     };
 
-    return boorus.firstWhereOrNull((e) => e.id == id);
+    return getBooruFromId(id);
   }
 }

--- a/lib/core/downloads/download_provider.dart
+++ b/lib/core/downloads/download_provider.dart
@@ -18,7 +18,7 @@ final downloadServiceProvider = Provider.family<DownloadService, BooruConfig>(
     return BackgroundDownloader();
   },
   dependencies: [
-    dioArgsProvider,
+    dioProvider,
     downloadNotificationProvider,
     currentBooruConfigProvider,
     settingsProvider,

--- a/lib/core/images/booru_image.dart
+++ b/lib/core/images/booru_image.dart
@@ -1,13 +1,16 @@
 // Flutter imports:
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 // Package imports:
+import 'package:dio/dio.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // Project imports:
 import 'package:boorusama/boorus/providers.dart';
 import 'package:boorusama/core/configs/configs.dart';
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
 import 'package:boorusama/dart.dart';
 import 'package:boorusama/foundation/http/http.dart';
@@ -47,8 +50,10 @@ class BooruImage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final config = ref.watchConfig;
+    final dio = ref.watch(dioProvider(config));
 
     return BooruRawImage(
+      dio: dio,
       imageUrl: imageUrl,
       placeholderUrl: placeholderUrl,
       borderRadius: borderRadius,
@@ -71,6 +76,7 @@ class BooruImage extends ConsumerWidget {
 class BooruRawImage extends StatelessWidget {
   const BooruRawImage({
     super.key,
+    required this.dio,
     required this.imageUrl,
     this.placeholderUrl,
     this.borderRadius,
@@ -84,6 +90,7 @@ class BooruRawImage extends StatelessWidget {
     this.headers = const {},
   });
 
+  final Dio dio;
   final String imageUrl;
   final String? placeholderUrl;
   final BorderRadius? borderRadius;
@@ -112,8 +119,9 @@ class BooruRawImage extends StatelessWidget {
   Widget _builderNormalImage() {
     return NullableAspectRatio(
       aspectRatio: aspectRatio,
-      child: ExtendedImage.network(
+      child: DioExtendedImage.network(
         imageUrl,
+        dio: dio,
         width: width,
         height: height,
         cacheHeight: cacheHeight,
@@ -138,8 +146,9 @@ class BooruRawImage extends StatelessWidget {
     return Column(
       children: [
         Expanded(
-          child: ExtendedImage.network(
+          child: DioExtendedImage.network(
             imageUrl,
+            dio: dio,
             width: width ?? double.infinity,
             height: height ?? double.infinity,
             headers: headers,
@@ -165,8 +174,9 @@ class BooruRawImage extends StatelessWidget {
                 borderRadius: borderRadius ?? _defaultRadius,
               ),
               (url) => url.isNotEmpty
-                  ? ExtendedImage.network(
+                  ? DioExtendedImage.network(
                       url,
+                      dio: dio,
                       width: width ?? double.infinity,
                       height: height ?? double.infinity,
                       cacheHeight: cacheHeight,

--- a/lib/core/images/dio_extended_image.dart
+++ b/lib/core/images/dio_extended_image.dart
@@ -1,0 +1,104 @@
+// Flutter imports:
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:dio/dio.dart';
+import 'package:extended_image/extended_image.dart';
+
+// Project imports:
+import 'package:boorusama/core/images/dio_extended_image_provider.dart';
+
+class DioExtendedImage extends ExtendedImage {
+  DioExtendedImage.network(
+    String url, {
+    Dio? dio,
+    super.key,
+    super.semanticLabel,
+    super.excludeFromSemantics = false,
+    super.width,
+    super.height,
+    super.color,
+    super.opacity,
+    super.colorBlendMode,
+    super.fit,
+    super.alignment = Alignment.center,
+    super.repeat = ImageRepeat.noRepeat,
+    super.centerSlice,
+    super.matchTextDirection = false,
+    super.gaplessPlayback = false,
+    super.filterQuality = FilterQuality.low,
+    super.loadStateChanged,
+    super.shape,
+    super.border,
+    super.borderRadius,
+    super.clipBehavior = Clip.antiAlias,
+    super.enableLoadState = true,
+    super.beforePaintImage,
+    super.afterPaintImage,
+    super.mode = ExtendedImageMode.none,
+    super.enableMemoryCache = true,
+    super.clearMemoryCacheIfFailed = true,
+    super.onDoubleTap,
+    super.initGestureConfigHandler,
+    super.enableSlideOutPage = false,
+    BoxConstraints? constraints,
+    CancellationToken? cancelToken,
+    int retries = 3,
+    Duration? timeLimit,
+    Map<String, String>? headers,
+    bool cache = true,
+    double scale = 1.0,
+    Duration timeRetry = const Duration(milliseconds: 100),
+    super.extendedImageEditorKey,
+    super.initEditorConfigHandler,
+    super.heroBuilderForSlidingPage,
+    super.clearMemoryCacheWhenDispose = false,
+    super.handleLoadingProgress = false,
+    super.extendedImageGestureKey,
+    int? cacheWidth,
+    int? cacheHeight,
+    super.isAntiAlias = false,
+    String? cacheKey,
+    bool printError = true,
+    double? compressionRatio,
+    int? maxBytes,
+    bool cacheRawData = false,
+    String? imageCacheName,
+    Duration? cacheMaxAge,
+    super.layoutInsets = EdgeInsets.zero,
+  })  : assert(cacheWidth == null || cacheWidth > 0),
+        assert(cacheHeight == null || cacheHeight > 0),
+        assert(constraints == null || constraints.debugAssertIsValid()),
+        assert(cacheWidth == null || cacheWidth > 0),
+        assert(cacheHeight == null || cacheHeight > 0),
+        super(
+          image: ExtendedResizeImage.resizeIfNeeded(
+            provider: DioExtendedNetworkImageProvider(
+              url,
+              dio: dio,
+              scale: scale,
+              headers: headers,
+              cache: cache,
+              cancelToken: cancelToken,
+              retries: retries,
+              timeRetry: timeRetry,
+              timeLimit: timeLimit,
+              cacheKey: cacheKey,
+              printError: printError,
+              cacheRawData: cacheRawData,
+              imageCacheName: imageCacheName,
+              cacheMaxAge: cacheMaxAge,
+            ),
+            compressionRatio: compressionRatio,
+            maxBytes: maxBytes,
+            cacheWidth: cacheWidth,
+            cacheHeight: cacheHeight,
+            cacheRawData: cacheRawData,
+            imageCacheName: imageCacheName,
+          ),
+          constraints: (width != null || height != null)
+              ? constraints?.tighten(width: width, height: height) ??
+                  BoxConstraints.tightFor(width: width, height: height)
+              : constraints,
+        );
+}

--- a/lib/core/images/dio_extended_image_provider.dart
+++ b/lib/core/images/dio_extended_image_provider.dart
@@ -1,0 +1,375 @@
+// Dart imports:
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui' as ui show Codec;
+
+// Flutter imports:
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+// Package imports:
+import 'package:dio/dio.dart';
+import 'package:extended_image/extended_image.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+
+// Project imports:
+import 'package:boorusama/foundation/networking/dio.dart';
+
+class DioExtendedNetworkImageProvider
+    extends ImageProvider<ExtendedNetworkImageProvider>
+    with ExtendedImageProvider<ExtendedNetworkImageProvider>
+    implements ExtendedNetworkImageProvider {
+  /// Creates an object that fetches the image at the given URL.
+  ///
+  /// The arguments must not be null.
+  DioExtendedNetworkImageProvider(
+    this.url, {
+    this.dio,
+    this.scale = 1.0,
+    this.headers,
+    this.cache = false,
+    this.retries = 3,
+    this.timeLimit,
+    this.timeRetry = const Duration(milliseconds: 100),
+    this.cacheKey,
+    this.printError = true,
+    this.cacheRawData = false,
+    this.cancelToken,
+    this.imageCacheName,
+    this.cacheMaxAge,
+  });
+
+  /// The [Dio] client that'll be used to make image fetch requests.
+  final Dio? dio;
+
+  /// The name of [ImageCache], you can define custom [ImageCache] to store this provider.
+  @override
+  final String? imageCacheName;
+
+  /// Whether cache raw data if you need to get raw data directly.
+  /// For example, we need raw image data to edit,
+  /// but [ui.Image.toByteData()] is very slow. So we cache the image
+  /// data here.
+  @override
+  final bool cacheRawData;
+
+  /// The time limit to request image
+  @override
+  final Duration? timeLimit;
+
+  /// The time to retry to request
+  @override
+  final int retries;
+
+  /// The time duration to retry to request
+  @override
+  final Duration timeRetry;
+
+  /// Whether cache image to local
+  @override
+  final bool cache;
+
+  /// The URL from which the image will be fetched.
+  @override
+  final String url;
+
+  /// The scale to place in the [ImageInfo] object of the image.
+  @override
+  final double scale;
+
+  /// The HTTP headers that will be used with [HttpClient.get] to fetch image from network.
+  @override
+  final Map<String, String>? headers;
+
+  /// The token to cancel network request
+  @override
+  final CancellationToken? cancelToken;
+
+  /// Custom cache key
+  @override
+  final String? cacheKey;
+
+  /// print error
+  @override
+  final bool printError;
+
+  /// The max duration to cahce image.
+  /// After this time the cache is expired and the image is reloaded.
+  @override
+  final Duration? cacheMaxAge;
+
+  @override
+  ImageStreamCompleter loadImage(
+    ExtendedNetworkImageProvider key,
+    ImageDecoderCallback decode,
+  ) {
+    // Ownership of this controller is handed off to [_loadAsync]; it is that
+    // method's responsibility to close the controller's stream when the image
+    // has been loaded or an error is thrown.
+    final StreamController<ImageChunkEvent> chunkEvents =
+        StreamController<ImageChunkEvent>();
+
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(
+        key,
+        chunkEvents,
+        decode,
+      ),
+      scale: key.scale,
+      chunkEvents: chunkEvents.stream,
+      debugLabel: key.url,
+      informationCollector: () {
+        return <DiagnosticsNode>[
+          DiagnosticsProperty<ImageProvider>('Image provider', this),
+          DiagnosticsProperty<ExtendedNetworkImageProvider>('Image key', key),
+        ];
+      },
+    );
+  }
+
+  @override
+  Future<ExtendedNetworkImageProvider> obtainKey(
+      ImageConfiguration configuration) {
+    return SynchronousFuture<ExtendedNetworkImageProvider>(this);
+  }
+
+  Future<ui.Codec> _loadAsync(
+    ExtendedNetworkImageProvider key,
+    StreamController<ImageChunkEvent> chunkEvents,
+    ImageDecoderCallback decode,
+  ) async {
+    assert(key == this);
+    final String md5Key = cacheKey ?? keyToMd5(key.url);
+    ui.Codec? result;
+    if (cache) {
+      try {
+        final Uint8List? data = await _loadCache(
+          key,
+          chunkEvents,
+          md5Key,
+        );
+        if (data != null) {
+          result = await instantiateImageCodec(data, decode);
+        }
+      } catch (e) {
+        if (printError) {
+          if (kDebugMode) {
+            print(e);
+          }
+        }
+      }
+    }
+
+    if (result == null) {
+      try {
+        final Uint8List? data = await _loadNetwork(
+          key,
+          chunkEvents,
+        );
+        if (data != null) {
+          result = await instantiateImageCodec(data, decode);
+        }
+      } catch (e) {
+        if (printError) {
+          if (kDebugMode) {
+            print(e);
+          }
+        }
+      }
+    }
+
+    //Failed to load
+    if (result == null) {
+      return Future<ui.Codec>.error(StateError('Failed to load $url.'));
+    }
+
+    return result;
+  }
+
+  /// Get the image from cache folder.
+  Future<Uint8List?> _loadCache(
+    ExtendedNetworkImageProvider key,
+    StreamController<ImageChunkEvent>? chunkEvents,
+    String md5Key,
+  ) async {
+    final Directory cacheImagesDirectory = Directory(
+        join((await getTemporaryDirectory()).path, cacheImageFolderName));
+    Uint8List? data;
+    // exist, try to find cache image file
+    if (await cacheImagesDirectory.exists()) {
+      final File cacheFlie = File(join(cacheImagesDirectory.path, md5Key));
+      if (await cacheFlie.exists()) {
+        if (key.cacheMaxAge != null) {
+          final DateTime now = DateTime.now();
+          final FileStat fs = cacheFlie.statSync();
+          if (now.subtract(key.cacheMaxAge!).isAfter(fs.changed)) {
+            await cacheFlie.delete(recursive: true);
+          } else {
+            data = await cacheFlie.readAsBytes();
+          }
+        } else {
+          data = await cacheFlie.readAsBytes();
+        }
+      }
+    }
+    // create folder
+    else {
+      await cacheImagesDirectory.create();
+    }
+    // load from network
+    if (data == null) {
+      data = await _loadNetwork(
+        key,
+        chunkEvents,
+      );
+      if (data != null) {
+        // cache image file
+        await File(join(cacheImagesDirectory.path, md5Key)).writeAsBytes(data);
+      }
+    }
+
+    return data;
+  }
+
+  /// Get the image from network.
+  Future<Uint8List?> _loadNetwork(
+    ExtendedNetworkImageProvider key,
+    StreamController<ImageChunkEvent>? chunkEvents,
+  ) async {
+    try {
+      final Uri resolved = Uri.base.resolve(key.url);
+      final Response<List<int>>? response =
+          await _tryGetResponse(resolved, chunkEvents);
+      if (response == null || response.data == null) {
+        return null;
+      }
+
+      final Uint8List bytes = Uint8List.fromList(response.data!);
+      if (bytes.lengthInBytes == 0) {
+        return Future<Uint8List>.error(
+            StateError('NetworkImage is an empty file: $resolved'));
+      }
+
+      return bytes;
+    } on OperationCanceledError catch (_) {
+      if (printError) {
+        if (kDebugMode) {
+          print('User cancel request $url.');
+        }
+      }
+      return Future<Uint8List>.error(StateError('User cancel request $url.'));
+    } catch (e) {
+      if (printError) {
+        if (kDebugMode) {
+          print(e);
+        }
+      }
+      // [ExtendedImage.clearMemoryCacheIfFailed] can clear cache
+      // Depending on where the exception was thrown, the image cache may not
+      // have had a chance to track the key in the cache at all.
+      // Schedule a microtask to give the cache a chance to add the key.
+      // scheduleMicrotask(() {
+      //   PaintingBinding.instance.imageCache.evict(key);
+      // });
+      // rethrow;
+    } finally {
+      await chunkEvents?.close();
+    }
+    return null;
+  }
+
+  // Http get with cancel, delay try again
+  Future<Response<List<int>>?> _tryGetResponse(
+    Uri resolved,
+    StreamController<ImageChunkEvent>? chunkEvents,
+  ) async {
+    cancelToken?.throwIfCancellationRequested();
+    return await RetryHelper.tryRun<Response<List<int>>>(
+      () async {
+        return CancellationTokenSource.register(
+          cancelToken,
+          (dio ?? globalDio).getUri<List<int>>(
+            resolved,
+            options: Options(
+              responseType: ResponseType.bytes,
+              headers: headers,
+              receiveTimeout: timeLimit,
+              validateStatus: (status) => status == HttpStatus.ok,
+            ),
+            onReceiveProgress: chunkEvents != null
+                ? (count, total) => chunkEvents.add(ImageChunkEvent(
+                    cumulativeBytesLoaded: count, expectedTotalBytes: total))
+                : null,
+          ),
+        );
+      },
+      cancelToken: cancelToken,
+      timeRetry: timeRetry,
+      retries: retries,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ExtendedNetworkImageProvider &&
+        url == other.url &&
+        scale == other.scale &&
+        cacheRawData == other.cacheRawData &&
+        timeLimit == other.timeLimit &&
+        cancelToken == other.cancelToken &&
+        timeRetry == other.timeRetry &&
+        cache == other.cache &&
+        cacheKey == other.cacheKey &&
+        //headers == other.headers &&
+        retries == other.retries &&
+        imageCacheName == other.imageCacheName &&
+        cacheMaxAge == other.cacheMaxAge;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        url,
+        scale,
+        cacheRawData,
+        timeLimit,
+        cancelToken,
+        timeRetry,
+        cache,
+        cacheKey,
+        //headers,
+        retries,
+        imageCacheName,
+        cacheMaxAge,
+      );
+
+  @override
+  String toString() => '$runtimeType("$url", scale: $scale)';
+
+  @override
+
+  /// Get network image data from cached
+  Future<Uint8List?> getNetworkImageData({
+    StreamController<ImageChunkEvent>? chunkEvents,
+  }) async {
+    final String uId = cacheKey ?? keyToMd5(url);
+
+    if (cache) {
+      return await _loadCache(
+        this,
+        chunkEvents,
+        uId,
+      );
+    }
+
+    return await _loadNetwork(
+      this,
+      chunkEvents,
+    );
+  }
+
+  static final Dio globalDio = Dio()..httpClientAdapter = newNativeAdapter();
+}

--- a/lib/core/images/interactive_booru_image.dart
+++ b/lib/core/images/interactive_booru_image.dart
@@ -2,14 +2,13 @@
 import 'package:flutter/material.dart';
 
 // Package imports:
-import 'package:extended_image/extended_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // Project imports:
 import 'package:boorusama/boorus/providers.dart';
 import 'package:boorusama/core/configs/configs.dart';
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
-import 'package:boorusama/foundation/http/http.dart';
 import 'package:boorusama/widgets/widgets.dart';
 
 class InteractiveBooruImage extends ConsumerStatefulWidget {
@@ -43,7 +42,7 @@ class _InteractiveBooruImageState extends ConsumerState<InteractiveBooruImage> {
   @override
   Widget build(BuildContext context) {
     final config = ref.watchConfig;
-    final ua = ref.watch(userAgentGeneratorProvider(config)).generate();
+    final dio = ref.watch(dioProvider(config));
 
     if (widget.imageUrl.isEmpty) {
       return NullableAspectRatio(
@@ -64,8 +63,9 @@ class _InteractiveBooruImageState extends ConsumerState<InteractiveBooruImage> {
               child: LayoutBuilder(
                 builder: (context, constraints) => Stack(
                   children: [
-                    ExtendedImage.network(
+                    DioExtendedImage.network(
                       widget.imageUrl,
+                      dio: dio,
                       width: constraints.maxWidth.isFinite
                           ? constraints.maxWidth
                           : null,
@@ -75,7 +75,6 @@ class _InteractiveBooruImageState extends ConsumerState<InteractiveBooruImage> {
                       fit: BoxFit.contain,
                       cacheMaxAge: kDefaultImageCacheDuration,
                       headers: {
-                        AppHttpHeaders.userAgentHeader: ua,
                         ...ref.watch(extraHttpHeaderProvider(config)),
                       },
                     ),
@@ -85,8 +84,9 @@ class _InteractiveBooruImageState extends ConsumerState<InteractiveBooruImage> {
               ),
             )
           : LayoutBuilder(
-              builder: (context, constraints) => ExtendedImage.network(
+              builder: (context, constraints) => DioExtendedImage.network(
                 widget.imageUrl,
+                dio: dio,
                 width:
                     constraints.maxWidth.isFinite ? constraints.maxWidth : null,
                 height: constraints.maxHeight.isFinite
@@ -95,7 +95,6 @@ class _InteractiveBooruImageState extends ConsumerState<InteractiveBooruImage> {
                 cacheMaxAge: kDefaultImageCacheDuration,
                 fit: BoxFit.contain,
                 headers: {
-                  AppHttpHeaders.userAgentHeader: ua,
                   ...ref.watch(extraHttpHeaderProvider(config)),
                 },
               ),

--- a/lib/core/images/original_image_page.dart
+++ b/lib/core/images/original_image_page.dart
@@ -3,19 +3,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 // Package imports:
-import 'package:extended_image/extended_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 // Project imports:
 import 'package:boorusama/boorus/providers.dart';
 import 'package:boorusama/core/configs/configs.dart';
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
 import 'package:boorusama/core/posts/posts.dart';
 import 'package:boorusama/dart.dart';
 import 'package:boorusama/flutter.dart';
 import 'package:boorusama/foundation/display.dart';
-import 'package:boorusama/foundation/http/http.dart';
 import 'package:boorusama/foundation/mobile.dart';
 import 'package:boorusama/widgets/widgets.dart';
 
@@ -186,6 +185,7 @@ class _OriginalImagePageState extends ConsumerState<OriginalImagePage> {
 
   Widget _buildImage() {
     final config = ref.watchConfig;
+    final dio = ref.watch(dioProvider(config));
 
     return Hero(
       tag: '${widget.id}_hero',
@@ -195,11 +195,10 @@ class _OriginalImagePageState extends ConsumerState<OriginalImagePage> {
             zoom = value;
           });
         },
-        child: ExtendedImage.network(
+        child: DioExtendedImage.network(
           widget.imageUrl,
+          dio: dio,
           headers: {
-            AppHttpHeaders.userAgentHeader:
-                ref.watch(userAgentGeneratorProvider(config)).generate(),
             ...ref.watch(extraHttpHeaderProvider(config)),
           },
         ),

--- a/lib/core/posts/details/common.dart
+++ b/lib/core/posts/details/common.dart
@@ -2,12 +2,12 @@
 import 'package:flutter/material.dart';
 
 // Package imports:
-import 'package:extended_image/extended_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // Project imports:
 import 'package:boorusama/boorus/providers.dart';
 import 'package:boorusama/core/configs/configs.dart';
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
 import 'package:boorusama/core/posts/posts.dart';
 
@@ -31,16 +31,17 @@ class PostDetailsPreloadImage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final config = ref.watchConfig;
-    return ExtendedImage.network(
+    final dio = ref.watch(dioProvider(config));
+
+    return DioExtendedImage.network(
       url,
+      dio: dio,
       width: 1,
       height: 1,
       cacheHeight: 10,
       cacheWidth: 10,
       cacheMaxAge: kDefaultImageCacheDuration,
       headers: {
-        AppHttpHeaders.userAgentHeader:
-            ref.watch(userAgentGeneratorProvider(config)).generate(),
         ...ref.watch(extraHttpHeaderProvider(config)),
       },
     );

--- a/lib/core/posts/details/common.dart
+++ b/lib/core/posts/details/common.dart
@@ -10,7 +10,6 @@ import 'package:boorusama/boorus/providers.dart';
 import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/core/images/images.dart';
 import 'package:boorusama/core/posts/posts.dart';
-import 'package:boorusama/foundation/http/http.dart';
 
 extension PostDetailsUtils<T extends Post> on List<T> {
   (T? prev, T? next) getPrevAndNextPosts(int index) {

--- a/lib/core/settings/widgets/help_us_translate_page.dart
+++ b/lib/core/settings/widgets/help_us_translate_page.dart
@@ -2,13 +2,13 @@
 import 'package:flutter/material.dart';
 
 // Package imports:
-import 'package:extended_image/extended_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 // Project imports:
 import 'package:boorusama/boorus/providers.dart';
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
 import 'package:boorusama/flutter.dart';
 import 'package:boorusama/foundation/url_launcher.dart';
@@ -57,7 +57,7 @@ class HelpUseTranslatePage extends ConsumerWidget {
                       ],
                     ),
                     const SizedBox(height: 24),
-                    ExtendedImage.network(
+                    DioExtendedImage.network(
                       appInfo.translationBadgeUrl,
                       height: 66,
                       width: 287,

--- a/lib/core/widgets/booru_logo.dart
+++ b/lib/core/widgets/booru_logo.dart
@@ -7,6 +7,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 // Project imports:
 import 'package:boorusama/core/configs/configs.dart';
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
 import 'package:boorusama/core/posts/posts.dart';
 
@@ -54,7 +55,7 @@ class BooruLogo extends StatelessWidget {
     return PostSource.from(source).whenWeb(
       (s) => FittedBox(
         child: s.faviconType == FaviconType.network
-            ? ExtendedImage.network(
+            ? DioExtendedImage.network(
                 s.faviconUrl,
                 width: width ?? 24,
                 height: height ?? 24,

--- a/lib/foundation/http/dio_logger_interceptor.dart
+++ b/lib/foundation/http/dio_logger_interceptor.dart
@@ -5,15 +5,14 @@ import 'package:dio/dio.dart';
 import 'package:boorusama/core/configs/configs.dart';
 import 'package:boorusama/foundation/http/http_utils.dart';
 import 'package:boorusama/foundation/loggers/loggers.dart';
-import 'package:boorusama/foundation/path.dart';
 
-const _kImageExtensions = {
-  '.jpg',
-  '.jpeg',
-  '.png',
-  '.gif',
-  '.webp',
-};
+// const _kImageExtensions = {
+//   '.jpg',
+//   '.jpeg',
+//   '.png',
+//   '.gif',
+//   '.webp',
+// };
 
 class LoggingInterceptor extends Interceptor {
   LoggingInterceptor({
@@ -27,12 +26,13 @@ class LoggingInterceptor extends Interceptor {
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    // Don't log image requests
-    final ext = extension(options.uri.toString());
-    if (_kImageExtensions.contains(ext)) {
-      super.onRequest(options, handler);
-      return;
-    }
+    // NOTE: Commented out while new image request system is still new
+    // // Don't log image requests
+    // final ext = extension(options.uri.toString());
+    // if (_kImageExtensions.contains(ext)) {
+    //   super.onRequest(options, handler);
+    //   return;
+    // }
 
     logger.logI('Network', 'Sending ${options.method} to ${options.uri}');
     requestTimeLogs[options.uri.toString()] = DateTime.now();
@@ -41,12 +41,12 @@ class LoggingInterceptor extends Interceptor {
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
-    final ext = extension(response.requestOptions.uri.toString());
-
-    if (_kImageExtensions.contains(ext)) {
-      super.onResponse(response, handler);
-      return;
-    }
+    // NOTE: Commented out while new image request system is still new
+    // final ext = extension(response.requestOptions.uri.toString());
+    // if (_kImageExtensions.contains(ext)) {
+    //   super.onResponse(response, handler);
+    //   return;
+    // }
 
     final duration = getRequestDuration(response.requestOptions);
     final durationText = _parseRequestDuration(duration);
@@ -62,12 +62,12 @@ class LoggingInterceptor extends Interceptor {
   void onError(DioException err, ErrorInterceptorHandler handler) {
     final response = err.response;
 
-    final ext = extension(response?.requestOptions.uri.toString() ?? '');
-
-    if (_kImageExtensions.contains(ext)) {
-      super.onError(err, handler);
-      return;
-    }
+    // NOTE: Commented out while new image request system is still new
+    // final ext = extension(response?.requestOptions.uri.toString() ?? '');
+    // if (_kImageExtensions.contains(ext)) {
+    //   super.onError(err, handler);
+    //   return;
+    // }
 
     final duration = getRequestDuration(response?.requestOptions);
     final durationText = _parseRequestDuration(duration);

--- a/lib/widgets/website_logo.dart
+++ b/lib/widgets/website_logo.dart
@@ -6,6 +6,7 @@ import 'package:extended_image/extended_image.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 // Project imports:
+import 'package:boorusama/core/images/dio_extended_image.dart';
 import 'package:boorusama/core/images/images.dart';
 
 const _unknownSize = 26.0;
@@ -40,7 +41,7 @@ class WebsiteLogo extends StatelessWidget {
         minWidth: size,
         minHeight: size,
       ),
-      child: ExtendedImage.network(
+      child: DioExtendedImage.network(
         url,
         clearMemoryCacheIfFailed: false,
         cacheMaxAge: kDefaultImageCacheDuration,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -247,6 +247,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  cronet_http:
+    dependency: transitive
+    description:
+      name: cronet_http
+      sha256: "3af9c4d57bf07ef4b307e77b22be4ad61bea19ee6ff65e62184863f3a09f1415"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
   cross_file:
     dependency: transitive
     description:
@@ -271,6 +279,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.3"
+  cupertino_http:
+    dependency: transitive
+    description:
+      name: cupertino_http
+      sha256: "7e75c45a27cc13a886ab0a1e4d8570078397057bd612de9d24fe5df0d9387717"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.1"
   custom_sliding_segmented_control:
     dependency: "direct main"
     description:
@@ -844,6 +860,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  http_profile:
+    dependency: transitive
+    description:
+      name: http_profile
+      sha256: "7e679e355b09aaee2ab5010915c932cce3f2d1c11c3b2dc177891687014ffa78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   image:
     dependency: transitive
     description:
@@ -892,6 +916,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.1"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: f377c585ea9c08d48b427dc2e03780af2889d1bb094440da853c6883c1acba4b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   js:
     dependency: transitive
     description:
@@ -1100,6 +1132,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.6.0"
+  native_dio_adapter:
+    dependency: "direct main"
+    description:
+      name: native_dio_adapter
+      sha256: "4c925ba15a44478be0eb6e97b62a1c1d07e56b28e566283dbcb15e58418bdaae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   nm:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,7 @@ dependencies:
   media_scanner: ^2.1.0
   modal_bottom_sheet: ^3.0.0-pre
   multi_split_view: ^3.5.0
+  native_dio_adapter: ^1.3.0
   oktoast: ^3.4.0
   package_info_plus: ^8.0.2
   path: ^1.8.3


### PR DESCRIPTION
This PR basically makes it so that all requests go through [`package:cronet_http`](https://pub.dev/packages/cronet_http) (on Android) or [`package:cupertino_http`](https://pub.dev/packages/cupertino_http) (on MacOS/iOS) using [`package:native_dio_adapter`](https://pub.dev/packages/native_dio_adapter).

From the [`package:native_dio_adapter`](https://pub.dev/packages/native_dio_adapter) page:

> Using the native platform implementation, rather than the socket-based [dart:io HttpClient](https://api.dart.dev/stable/dart-io/HttpClient-class.html) implementation, has several advantages:
> - It automatically supports platform features such VPNs and HTTP proxies.
> - It supports many more configuration options such as only allowing access through WiFi and blocking cookies.
> - It supports more HTTP features such as HTTP/3 and custom redirect handling.

This enables us in the future to add support for blocking image loading outside of WiFi or metered connections, however I did not want to do more than needed in this PR.

This PR also changes the security settings for the app to allow user-added/user-installed CAs so that people can access their own self-hosted boorus that use self-signed certificates.

Fixes #463.