### PR TITLE
Allow details and slideshow to load in background

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -1,6 +1,12 @@
-cd packages/i18n && dart run slang &
-cd packages/i18n && dart run tools/generate_language.dart &
-cd packages/booru_clients && dart run tools/generate_config.dart &
-cd packages/booru_clients && dart run tools/generate_yaml_configs.dart &
-cd packages/booru_clients && dart run tools/generate_registry.dart &
+#!/usr/bin/env bash
+echo == slang
+cd ./packages/i18n && flutter pub run slang; cd ~-
+echo == generate language
+cd ./packages/i18n && flutter pub run tools/generate_language.dart; cd ~-
+echo == generate config
+cd ./packages/booru_clients && flutter pub run tools/generate_config.dart; cd ~-
+echo == generate yaml
+cd ./packages/booru_clients && flutter pub run tools/generate_yaml_configs.dart; cd ~-
+echo == generate registry
+cd ./packages/booru_clients && flutter pub run tools/generate_registry.dart; cd ~-
 wait

--- a/lib/boorus/anime-pictures/anime_pictures_builder.dart
+++ b/lib/boorus/anime-pictures/anime_pictures_builder.dart
@@ -52,7 +52,7 @@ class AnimePicturesBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as AnimePicturesPost).toList();
+    final posts = payload.posts.listingMap((e) => e as AnimePicturesPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/anime-pictures/posts/widgets.dart
+++ b/lib/boorus/anime-pictures/posts/widgets.dart
@@ -40,7 +40,7 @@ class AnimePicturesRelatedPostsSection extends ConsumerWidget {
                       mediaUrlResolver.resolveMediaUrl(post, configViewer),
                   onTap: (index) => goToPostDetailsPageFromPosts(
                     ref: ref,
-                    posts: posts,
+                    posts: DetailsPostsListing.list(posts: posts),
                     initialIndex: index,
                     initialThumbnailUrl: mediaUrlResolver.resolveMediaUrl(
                       posts[index],

--- a/lib/boorus/danbooru/danbooru_builder.dart
+++ b/lib/boorus/danbooru/danbooru_builder.dart
@@ -82,8 +82,7 @@ class DanbooruBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as DanbooruPost).toList();
-
+    final posts = payload.posts.listingMap((e) => e as DanbooruPost);
     return PostDetailsScope<DanbooruPost>(
       initialIndex: payload.initialIndex,
       initialThumbnailUrl: payload.initialThumbnailUrl,

--- a/lib/boorus/danbooru/posts/details/src/widgets/danbooru_related_posts_section.dart
+++ b/lib/boorus/danbooru/posts/details/src/widgets/danbooru_related_posts_section.dart
@@ -32,7 +32,7 @@ class DanbooruRelatedPostsSection extends ConsumerWidget {
       ),
       onTap: (index) => goToPostDetailsPageFromPosts(
         ref: ref,
-        posts: posts,
+        posts: DetailsPostsListing.list(posts: posts),
         initialIndex: index,
         initialThumbnailUrl: posts[index].url720x720,
       ),

--- a/lib/boorus/e621/e621_builder.dart
+++ b/lib/boorus/e621/e621_builder.dart
@@ -75,7 +75,7 @@ class E621Builder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as E621Post).toList();
+    final posts = payload.posts.listingMap((e) => e as E621Post);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/eshuushuu/eshuushuu_builder.dart
+++ b/lib/boorus/eshuushuu/eshuushuu_builder.dart
@@ -79,7 +79,7 @@ class EshuushuuBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as EshuushuuPost).toList();
+    final posts = payload.posts.listingMap((e) => e as EshuushuuPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/gelbooru/gelbooru_builder.dart
+++ b/lib/boorus/gelbooru/gelbooru_builder.dart
@@ -66,7 +66,7 @@ class GelbooruBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as GelbooruPost).toList();
+    final posts = payload.posts.listingMap((e) => e as GelbooruPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/gelbooru_v2/posts/widgets.dart
+++ b/lib/boorus/gelbooru_v2/posts/widgets.dart
@@ -64,7 +64,7 @@ class GelbooruV2PostDetailsPage extends ConsumerWidget {
       );
     }
 
-    final posts = payload.posts.map((e) => e as GelbooruV2Post).toList();
+    final posts = payload.posts.listingMap((e) => e as GelbooruV2Post);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,
@@ -92,7 +92,7 @@ class _PayloadPostDetailsPage<T extends Post> extends ConsumerWidget {
     return PostDetailsScope(
       initialIndex: payload.initialIndex,
       initialThumbnailUrl: payload.initialThumbnailUrl,
-      posts: payload.posts.map((e) => e as GelbooruV2Post).toList(),
+      posts: payload.posts.listingMap((e) => e as GelbooruV2Post),
       scrollController: payload.scrollController,
       dislclaimer: payload.dislclaimer,
       child: const DefaultPostDetailsPage<GelbooruV2Post>(),
@@ -129,7 +129,7 @@ class _PostDetailsDataLoadingTransitionPage extends ConsumerWidget {
 
             final detailsContext = DetailsRouteContext(
               initialIndex: 0,
-              posts: [post],
+              posts: DetailsPostsListing.list(posts: [post]),
               scrollController: null,
               isDesktop: false,
               hero: false,
@@ -198,7 +198,7 @@ class GelbooruV2RelatedPostsSection extends ConsumerWidget {
                   ),
                   onTap: (index) => goToPostDetailsPageFromPosts(
                     ref: ref,
-                    posts: data,
+                    posts: DetailsPostsListing.list(posts: data),
                     initialIndex: index,
                     initialThumbnailUrl: data[index].sampleImageUrl,
                   ),

--- a/lib/boorus/hybooru/hybooru_builder.dart
+++ b/lib/boorus/hybooru/hybooru_builder.dart
@@ -30,7 +30,7 @@ class HybooruBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as HybooruPost).toList();
+    final posts = payload.posts.listingMap((e) => e as HybooruPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/hydrus/hydrus_builder.dart
+++ b/lib/boorus/hydrus/hydrus_builder.dart
@@ -61,7 +61,7 @@ class HydrusBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as HydrusPost).toList();
+    final posts = payload.posts.listingMap((e) => e as HydrusPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/moebooru/post_details/src/details_page.dart
+++ b/lib/boorus/moebooru/post_details/src/details_page.dart
@@ -20,7 +20,7 @@ class MoebooruPostDetailsPage extends StatelessWidget {
   const MoebooruPostDetailsPage({super.key});
 
   static Widget fromRouteData(DetailsRouteContext payload) {
-    final posts = payload.posts.map((e) => e as MoebooruPost).toList();
+    final posts = payload.posts.listingMap((e) => e as MoebooruPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,
@@ -66,7 +66,7 @@ class _MoebooruPostDetailsPageState
   final _transformController = TransformationController();
   final _isInitPage = ValueNotifier(true);
 
-  List<MoebooruPost> get posts => data.posts;
+  DetailsPostsListing<MoebooruPost> get posts => data.posts;
   PostDetailsController<MoebooruPost> get controller => data.controller;
 
   @override

--- a/lib/boorus/moebooru/post_details/src/widgets/related_post_section.dart
+++ b/lib/boorus/moebooru/post_details/src/widgets/related_post_section.dart
@@ -38,7 +38,7 @@ class MoebooruRelatedPostsSection extends ConsumerWidget {
               ),
               onTap: (index) => goToPostDetailsPageFromPosts(
                 ref: ref,
-                posts: posts,
+                posts: DetailsPostsListing.list(posts: posts),
                 initialIndex: index,
                 initialThumbnailUrl: posts[index].sampleImageUrl,
               ),

--- a/lib/boorus/philomena/philomena_builder.dart
+++ b/lib/boorus/philomena/philomena_builder.dart
@@ -49,7 +49,7 @@ class PhilomenaBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as PhilomenaPost).toList();
+    final posts = payload.posts.listingMap((e) => e as PhilomenaPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/sankaku/sankaku_builder.dart
+++ b/lib/boorus/sankaku/sankaku_builder.dart
@@ -55,7 +55,7 @@ class SankakuBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as SankakuPost).toList();
+    final posts = payload.posts.listingMap((e) => e as SankakuPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/shimmie2/shimmie2_builder.dart
+++ b/lib/boorus/shimmie2/shimmie2_builder.dart
@@ -52,7 +52,7 @@ class Shimmie2Builder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as Shimmie2Post).toList();
+    final posts = payload.posts.listingMap((e) => e as Shimmie2Post);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/szurubooru/szurubooru_builder.dart
+++ b/lib/boorus/szurubooru/szurubooru_builder.dart
@@ -84,7 +84,7 @@ class SzurubooruBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as SzurubooruPost).toList();
+    final posts = payload.posts.listingMap((e) => e as SzurubooruPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/boorus/zerochan/zerochan_builder.dart
+++ b/lib/boorus/zerochan/zerochan_builder.dart
@@ -30,7 +30,7 @@ class ZerochanBuilder extends BaseBooruBuilder {
 
   @override
   PostDetailsPageBuilder get postDetailsPageBuilder => (context, payload) {
-    final posts = payload.posts.map((e) => e as ZerochanPost).toList();
+    final posts = payload.posts.listingMap((e) => e as ZerochanPost);
 
     return PostDetailsScope(
       initialIndex: payload.initialIndex,

--- a/lib/core/bookmarks/src/pages/bookmark_details_page.dart
+++ b/lib/core/bookmarks/src/pages/bookmark_details_page.dart
@@ -12,6 +12,7 @@ import '../../../configs/config/providers.dart';
 import '../../../configs/config/types.dart';
 import '../../../downloads/downloader/providers.dart';
 import '../../../downloads/filename/types.dart';
+import '../../../posts/details/routes.dart';
 import '../../../posts/details/types.dart';
 import '../../../posts/details/widgets.dart';
 import '../../../posts/details_parts/types.dart';
@@ -46,7 +47,7 @@ class BookmarkDetailsPage extends ConsumerWidget {
         return PostDetailsScope(
           initialIndex: initialIndex,
           initialThumbnailUrl: initialThumbnailUrl,
-          posts: posts,
+          posts: DetailsPostsListing.list(posts: posts),
           scrollController: null,
           dislclaimer: null,
           child: const BookmarkDetailsPageInternal(),

--- a/lib/core/posts/details/src/routes/details_route_context.dart
+++ b/lib/core/posts/details/src/routes/details_route_context.dart
@@ -4,10 +4,12 @@ import 'dart:collection';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
 // Project imports:
 import '../../../../configs/config/types.dart';
+import '../../../details_pageview/src/post_details_page_view_controller.dart';
 import '../../../listing/providers.dart';
 import '../../../listing/types.dart';
 import '../../../post/types.dart';
@@ -33,10 +35,10 @@ class DetailsPostsListing<T extends Post> extends ListBase<T> {
   // Controller constructor
   DetailsPostsListing.controller({required PostGridController<dynamic> controller})
       : gridController = controller,
-        posts = (controller.pageMode == PageMode.paginated) ? controller.items.toList() : null, // FIXME: paginated mode unimplemented
-        _convert = ((i) => (i)),
+        posts =  null,
+        _convert = ((i) => i),
         dynlen = ValueNotifier<int>(controller.items.length){
-          _strategy = (controller.pageMode == PageMode.paginated) ? null : _InfiniteStrategy(controller, dynlen);
+          _strategy = (controller.pageMode == PageMode.paginated) ? _PaginatedStrategy(controller, dynlen) : _InfiniteStrategy(controller, dynlen);
         }
 
   // Shared-state constructor (for listingMap)
@@ -57,17 +59,16 @@ class DetailsPostsListing<T extends Post> extends ListBase<T> {
     return DetailsPostsListing<T2>._shared(
       this,
       (i) => converter(i)
-      // (item) {
-      //   if (item == null) return null;
-      //   return converter(item);
-      // },
     );
   }
 
-  set initial(int initialIndex) {
+  void setPostDetailsPageViewController(PostDetailsPageViewController postDetailsPage) {
     final strat = _strategy;
+    
     if (strat is _InfiniteStrategy) {
-      strat.indexOffset = initialIndex;
+      strat.indexOffset = postDetailsPage.initialPage;
+    } else if (strat is _PaginatedStrategy) {
+      strat.postDetailsPage = postDetailsPage;
     }
   }
 
@@ -137,9 +138,9 @@ class _InfiniteStrategy implements _ListingStrategy {
       seenIndices.add(index);
     }
 
-    final visible = length.value;
-    if (visible > 0 &&
-        seenLength >= (visible * 3 / 4).ceil() &&
+    final currentlyLoaded = length.value;
+    if (currentlyLoaded > 0 &&
+        seenLength >= (currentlyLoaded * 3 / 4).ceil() &&
         !fetchPending &&
         gridController.hasMore &&
         !gridController.loading &&
@@ -147,10 +148,10 @@ class _InfiniteStrategy implements _ListingStrategy {
       _triggerFetch();
     }
 
-    final isLastVisible = seenLength >= visible - 1;
+    final isLastVisible = seenLength >= currentlyLoaded - 1;
 
     final currentItemCount = gridController.items.length;
-    if (isLastVisible && currentItemCount > visible) {
+    if (isLastVisible && currentItemCount > currentlyLoaded) {
       _reveal(currentItemCount);
     }
   }
@@ -173,153 +174,190 @@ class _InfiniteStrategy implements _ListingStrategy {
   void dispose() {
   }
   
-
 }
 
-// // ========== Paginated Strategy (sliding‑window cache) ==========
-// class _PaginatedStrategy implements _ListingStrategy {
-//   _PaginatedStrategy(this.gridController) {
-//     gridController.itemsNotifier.addListener(onItemsUpdated);
-//     gridController.pageNotifier.addListener(_onPageChanged);
+// ========== Paginated Strategy Implementation ==========
+class _PaginatedStrategy implements _ListingStrategy {
+  _PaginatedStrategy(
+    this._controller,
+    this._dynlen,
+  ):
+  _firstPage = _controller.pageNotifier.value,
+  _lastPage = _controller.pageNotifier.value,
+  _forwards = _controller.items.toList()
+   {
+    _updateLength();
+    // Immediately start loading the previous page if it exists.
+    if (_controller.hasPreviousPage()) {
+      _loadPreviousPage();
+    }
+  }
 
-//     _currentControllerPage = gridController.page;
-//     if (gridController.items.isNotEmpty) {
-//       _pageCache[_currentControllerPage] = List.from(gridController.items);
-//     }
-//   }
+  final PostGridController<dynamic> _controller;
+  final ValueNotifier<int> _dynlen;
+  PostDetailsPageViewController? postDetailsPage;
 
-//   final PostGridController<dynamic> gridController;
-//   void Function(int) _updateLength = (l) => ();
+  // Own storage: backwards (reversed order) and forwards (normal order)
+  final List<dynamic> _forwards; // initialize in constructor
+  final List<dynamic> _backwards = []; // stored as [..., page_{N-1}_last, ..., page_{N-1}_0]
+  int _firstPage; // smallest page number currently in _backwards
+  int _lastPage;  // largest page number currently in _forwards
 
-//   final Map<int, List<dynamic>> _pageCache = {};
-//   var _baseOffset = 0;
-//   var _currentControllerPage = 1;
-//   var _isLoadingPage = false;
+  // Seen indices management
+  final Set<int> _seenIndices = {};
+  int? _lastMarkedIndex;
 
+  // Loading guard
+  var _loading = false;
 
-//   void _onPageChanged() {
-//     _currentControllerPage = gridController.page;
-//   }
+  @override
+  ValueNotifier<int>? get length => _dynlen;
 
-//   List<int> get _sortedPages => _pageCache.keys.toList()..sort();
-//   int get _cachedLength => _sortedPages.fold(0, (sum, p) => sum + _pageCache[p]!.length);
+  @override
+  dynamic getItemAt(int index) {
+    final backLen = _backwards.length;
+    if (index < backLen) {
+      // Combined list: backwards part is reversed.
+      return _backwards[backLen - 1 - index];
+    } else {
+      return _forwards[index - backLen];
+    }
+  }
 
-//   @override
-//   int get length => _baseOffset + _cachedLength;
+  @override
+  void markSeen(int index, {bool force = false}) {
+    // force is ignored – we simply let the set grow as requested.
+    if (_seenIndices.add(index)) {
+      _lastMarkedIndex = index;
+    }
+    _maybeLoadMorePages();
+  }
 
+  void _maybeLoadMorePages() {
+    final totalLen = _dynlen.value;
+    final seenCount = _seenIndices.length;
 
-//   @override
-//   dynamic? getItemAt(int index) {
-//     var runningOffset = _baseOffset;
-//     for (final page in _sortedPages) {
-//       final pageItems = _pageCache[page]!;
-//       if (index >= runningOffset && index < runningOffset + pageItems.length) {
-//         final localIndex = index - runningOffset;
-//         _prefetchIfNeeded(page, localIndex, pageItems.length);
-//         return pageItems[localIndex];
-//       }
-//       runningOffset += pageItems.length;
-//     }
+    // Threshold: 3/4 of the currently loaded items have been marked.
+    final thresholdReached = seenCount >= (totalLen * 3 / 4).ceil();
 
-//     // Not in cache – determine direction
-//     int targetPage;
-//     if (_pageCache.isEmpty) {
-//       targetPage = 1;
-//     } else if (index < _baseOffset) {
-//       targetPage = _sortedPages.first - 1;   // need older page
-//     } else {
-//       targetPage = _sortedPages.last + 1;    // need newer page
-//     }
+    if (thresholdReached && _lastMarkedIndex != null) {
+      final center = totalLen / 2;
+      if (_lastMarkedIndex! > center) {
+        // User has moved to the second half → load next page.
+        if (_controller.hasNextPage() && !_loading) {
+          _loadNextPage();
+        }
+      } else {
+        // User is in the first half → load previous page.
+        if (_controller.hasPreviousPage() && !_loading) {
+          _loadPreviousPage();
+        }
+      }
+    } else {
+      // Immediate edge triggers.
+      if (_seenIndices.contains(0) &&
+          _controller.hasPreviousPage() &&
+          !_loading) {
+        _loadPreviousPage();
+      }
+      if (_seenIndices.contains(totalLen - 1) &&
+          _controller.hasNextPage() &&
+          !_loading) {
+        _loadNextPage();
+      }
+    }
+  }
 
-//     Future.microtask(() => _loadPageIfNeeded(targetPage));
-//     return null;
-//   }
+  Future<void> _loadPreviousPage() async {
+    if (_loading) return;
+    _loading = true;
 
-//   void _prefetchIfNeeded(int page, int localIndex, int pageLength) {
-//     // Prefetch next page when near the end of current page
-//     if (localIndex >= pageLength - 2) {
-//       _loadPageIfNeeded(page + 1);
-//     }
-//     // Prefetch previous page when near the beginning (and not on first page)
-//     if (localIndex <= 1 && page > 1) {
-//       _loadPageIfNeeded(page - 1);
-//     }
-//   }
+    final targetPage = _firstPage - 1;
+    if (!_controller.hasPreviousPage() || targetPage < 1) {
+      _loading = false;
+      return;
+    }
 
-//   Future<void> _loadPageIfNeeded(int page) async {
-//     if (_isLoadingPage) return;
-//     if (_pageCache.containsKey(page)) return;
-//     if (page < 1) return;
+    try {
+      final newPageItems = await _fetchPage(targetPage);
+      if (newPageItems.isEmpty) {
+        // No items on that page – treat as end of data.
+        _loading = false;
+        return;
+      }
 
-//     _isLoadingPage = true;
-//     unawaited(Future.microtask(() async {
-//       try {
-//         // Snapshot current page before jumping away
-//         final currentPage = _currentControllerPage;
-//         if (gridController.items.isNotEmpty && !_pageCache.containsKey(currentPage)) {
-//           _addPageToCache(currentPage, List.from(gridController.items));
-//         }
+      final addedCount = newPageItems.length;
 
-//         await gridController.jumpToPage(page);
+      // Insert new page at the beginning of the combined list.
+      // Backwards list stores pages in reverse order, so we append the new
+      // page’s items in reverse order.
+      _backwards.addAll(newPageItems.reversed);
+      _firstPage = targetPage;
 
-//         // Cache the newly loaded page
-//         if (gridController.items.isNotEmpty) {
-//           _addPageToCache(page, List.from(gridController.items));
-//         }
+      // Update length.
+      _updateLength();
 
-//         _evictDistantPages(page);
-//         _updateLength(length);
-//       } finally {
-//         _isLoadingPage = false;
-//       }
-//     }));
-//   }
+      // Shift existing seen indices because new items were inserted before them.
+      final updatedIndices = <int>{};
+      for (final idx in _seenIndices) {
+        updatedIndices.add(idx + addedCount);
+      }
+      _seenIndices.clear();
+      _seenIndices.addAll(updatedIndices);
+      if (_lastMarkedIndex != null) {
+        _lastMarkedIndex = _lastMarkedIndex! + addedCount;
+      }
+      postDetailsPage!.jumpToPage(postDetailsPage!.currentPage.value + addedCount);
+    } finally {
+      _loading = false;
+    }
+  }
 
-//   void _addPageToCache(int page, List<dynamic> items) {
-//     final wasEmpty = _pageCache.isEmpty;
-//     final oldOldest = wasEmpty ? null : _sortedPages.first;
+  Future<void> _loadNextPage() async {
+    if (_loading) return;
+    _loading = true;
 
-//     _pageCache[page] = items;
+    final targetPage = _lastPage + 1;
+    if (!_controller.hasNextPage()) {
+      _loading = false;
+      return;
+    }
 
-//     if (!wasEmpty && page < oldOldest!) {
-//       // New page is older than previous oldest → it is now cached,
-//       // so its items are no longer "evicted". Subtract from baseOffset.
-//       _baseOffset -= items.length;
-//     }
-//   }
+    try {
+      final newPageItems = await _fetchPage(targetPage);
+      if (newPageItems.isEmpty) {
+        _loading = false;
+        return;
+      }
 
-//   void _evictDistantPages(int centerPage) {
-//     final pagesToRemove = _pageCache.keys.where((p) => (p - centerPage).abs() > 1).toList();
-//     if (pagesToRemove.isEmpty) return;
+      // Append to forwards (normal order).
+      _forwards.addAll(newPageItems);
+      _lastPage = targetPage;
+      _updateLength();
 
-//     pagesToRemove.sort();
-//     for (final page in pagesToRemove) {
-//       if (page == _sortedPages.first) {
-//         // This is the oldest page in cache; it's being evicted.
-//         // Add its length to baseOffset.
-//         _baseOffset += _pageCache[page]!.length;
-//       }
-//       _pageCache.remove(page);
-//     }
-//   }
+      // No index shift needed when appending at the end.
+    } finally {
+      _loading = false;
+    }
+  }
 
-//   @override
-//   void markSeen(int index, {bool force = false}) {
-//     getItemAt(index); // just ensure the page is loaded
-//   }
+  Future<List<dynamic>> _fetchPage(int page) async {
+    // Use a completer to wait for the controller’s items to be updated.
+    await _controller.jumpToPage(page);
+    return _controller.items.toList();
+  }
 
+  void _updateLength() {
+      _dynlen.value = _backwards.length + _forwards.length;
+  }
 
-//   @override
-//   void dispose() {
-//     gridController.itemsNotifier.removeListener(onItemsUpdated);
-//     gridController.pageNotifier.removeListener(_onPageChanged);
-//     _pageCache.clear();
-//   }
-// }
-
+  @override
+  void dispose() {
+  }
+}
 
 class DetailsRouteContext<T extends Post> extends Equatable {
-  DetailsRouteContext({
+  const DetailsRouteContext({
     required this.initialIndex,
     required this.posts,
     required this.scrollController,
@@ -328,9 +366,7 @@ class DetailsRouteContext<T extends Post> extends Equatable {
     required this.initialThumbnailUrl,
     required this.configSearch,
     this.dislclaimer,
-  }){
-    posts.initial = initialIndex;
-  }
+  });
 
   DetailsRouteContext<T> copyWith({
     int? initialIndex,

--- a/lib/core/posts/details/src/routes/details_route_context.dart
+++ b/lib/core/posts/details/src/routes/details_route_context.dart
@@ -14,7 +14,6 @@ import '../../../listing/providers.dart';
 import '../../../listing/types.dart';
 import '../../../post/types.dart';
 
-// ========== Internal Strategy Interface ==========
 abstract class _ListingStrategy {
   ValueNotifier<int>? get length;
   dynamic getItemAt(int index);
@@ -23,7 +22,6 @@ abstract class _ListingStrategy {
 }
 
 
-// ========== Public Wrapper Class ==========
 class DetailsPostsListing<T extends Post> extends ListBase<T> {
   // Static list constructor
   DetailsPostsListing.list({required List<T> this.posts})
@@ -107,7 +105,6 @@ class DetailsPostsListing<T extends Post> extends ListBase<T> {
   }
 }
 
-// ========== Infinite Strategy (exact replica of original logic) ==========
 class _InfiniteStrategy implements _ListingStrategy {
   _InfiniteStrategy(this.gridController, this.length);
 
@@ -122,8 +119,6 @@ class _InfiniteStrategy implements _ListingStrategy {
 
   @override
   dynamic getItemAt(int index) {
-    // The infinite strategy relies on the controller's items directly.
-    // No additional caching; just fetch from controller.
     return gridController.items.elementAtOrNull(index);
   }
 
@@ -150,9 +145,8 @@ class _InfiniteStrategy implements _ListingStrategy {
 
     final isLastVisible = seenLength >= currentlyLoaded - 1;
 
-    final currentItemCount = gridController.items.length;
-    if (isLastVisible && currentItemCount > currentlyLoaded) {
-      _reveal(currentItemCount);
+    if (isLastVisible) {
+      _reveal();
     }
   }
 
@@ -160,13 +154,17 @@ class _InfiniteStrategy implements _ListingStrategy {
     if (!gridController.hasMore) return;
     fetchPending = true;
     await gridController.fetchMore();
+    // already false means we already tried to reveal
+    if (!fetchPending) {
+      _reveal();
+    }
   }
 
-  void _reveal(int newLength) {
+  void _reveal() {    
     indexOffset = length.value;
     fetchPending = false;
     seenIndices.clear();
-    length.value = newLength;
+    length.value = gridController.items.length;
   }
 
 
@@ -176,7 +174,6 @@ class _InfiniteStrategy implements _ListingStrategy {
   
 }
 
-// ========== Paginated Strategy Implementation ==========
 class _PaginatedStrategy implements _ListingStrategy {
   _PaginatedStrategy(
     this._controller,
@@ -352,8 +349,7 @@ class _PaginatedStrategy implements _ListingStrategy {
   }
 
   @override
-  void dispose() {
-  }
+  void dispose() {}
 }
 
 class DetailsRouteContext<T extends Post> extends Equatable {

--- a/lib/core/posts/details/src/routes/details_route_context.dart
+++ b/lib/core/posts/details/src/routes/details_route_context.dart
@@ -1,4 +1,5 @@
 // Package imports:
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:equatable/equatable.dart';
@@ -11,192 +12,311 @@ import '../../../listing/providers.dart';
 import '../../../listing/types.dart';
 import '../../../post/types.dart';
 
-class _PaginationState {
-  /// A set tracking which indices (larger than indexOffset) have been accessed
-  final Set<int> seenIndices = {};
-  /// All indices below this offset were seen in a previous fetch cycle
-  /// and must not be re-added to [seenIndices].
-  var indexOffset = 0;
-
-  /// Whether we have dispatched a fetchMore call that hasn't been
-  /// reflected in a new reveal yet.
-  var fetchPending = false;
-  int get seenLength => seenIndices.length + indexOffset;
+// ========== Internal Strategy Interface ==========
+abstract class _ListingStrategy {
+  ValueNotifier<int>? get length;
+  dynamic getItemAt(int index);
+  void markSeen(int index, {bool force});
+  void dispose();
 }
 
+
+// ========== Public Wrapper Class ==========
 class DetailsPostsListing<T extends Post> extends ListBase<T> {
-  /// instantiate a version of this which handles a handles a static list
-  DetailsPostsListing.list({ required List<T> this.posts}):
-        gridController = null,
-        _getItem = ((index) => posts[index]),
-        _pagination = _PaginationState(),
+  // Static list constructor
+  DetailsPostsListing.list({required List<T> this.posts})
+      : gridController = null,
+        _convert = ((i) => i),
+        _strategy = null,
         dynlen = ValueNotifier<int>(posts.length);
 
-  /// instatiate a version of this which handles a controller. This should be preferred where possible.
-  DetailsPostsListing.controller({required PostGridController<dynamic> controller}):
-        gridController = controller,
-        posts = null,
-        _getItem = ((index) => controller.items.elementAtOrNull(index)),
-        _pagination = _PaginationState(),
-        dynlen = ValueNotifier<int>(controller.items.length) {
-    gridController!.itemsNotifier.addListener(_onItemsUpdated);
-  }
-   // shared-state constructor
-  DetailsPostsListing._shared(DetailsPostsListing<dynamic> source, this._getItem):
-        gridController = source.gridController,
+  // Controller constructor
+  DetailsPostsListing.controller({required PostGridController<dynamic> controller})
+      : gridController = controller,
+        posts = (controller.pageMode == PageMode.paginated) ? controller.items.toList() : null, // FIXME: paginated mode unimplemented
+        _convert = ((i) => (i)),
+        dynlen = ValueNotifier<int>(controller.items.length){
+          _strategy = (controller.pageMode == PageMode.paginated) ? null : _InfiniteStrategy(controller, dynlen);
+        }
+
+  // Shared-state constructor (for listingMap)
+  DetailsPostsListing._shared(DetailsPostsListing<dynamic> source, this._convert)
+      : gridController = source.gridController,
         posts = source.posts,
         dynlen = source.dynlen,
-        _pagination = source._pagination;
+        _strategy = source._strategy;
 
   final List<dynamic>? posts;
   final PostGridController<dynamic>? gridController;
   final ValueNotifier<int> dynlen;
-  final T? Function(int index) _getItem;
+  final T Function(dynamic) _convert;
+  _ListingStrategy? _strategy;
 
-  // --- pagination state ---
-  final _PaginationState _pagination;
 
   DetailsPostsListing<T2> listingMap<T2 extends Post>(T2 Function(T) converter) {
     return DetailsPostsListing<T2>._shared(
       this,
-      (index) => converter(this[index]),
+      (i) => converter(i)
+      // (item) {
+      //   if (item == null) return null;
+      //   return converter(item);
+      // },
     );
   }
-  
-  // ignore: avoid_setters_without_getters
-  set initial(int intialIndex) => _pagination.indexOffset = intialIndex;
 
-  @override
-  int get length => dynlen.value;
-
-  @override
-  set length(int _) {
-    // ListBase requires this to be implemented; mutations are not
-    // supported for the controller case.
-    throw UnsupportedError('DetailsPostsListing is read-only');
+  set initial(int initialIndex) {
+    final strat = _strategy;
+    if (strat is _InfiniteStrategy) {
+      strat.indexOffset = initialIndex;
+    }
   }
 
   @override
-  void operator []=(int index, T value) {
-    throw UnsupportedError('DetailsPostsListing is read-only');
+  int get length {
+    if (posts != null) return posts!.length;
+    return dynlen.value;
   }
-  
 
-  // hacky way to ensure paginated mode doesn't break
-  late T _latestItem;
+  @override
+  set length(int _) => throw UnsupportedError('DetailsPostsListing is read-only');
+
+  @override
+  void operator []=(int index, T value) => throw UnsupportedError('DetailsPostsListing is read-only');
+
   @override
   T operator [](int index) {
-    if (index == 1 || index == 2 || index == 3) {
-      return _latestItem;
+    // Static list case
+    if (posts != null) {
+      return _convert(posts![index]);
     }
-    var item = _getItem(index);
-    
-    if (item == null){
-      switch (gridController!.pageMode) {
-        case PageMode.infinite:
-          // this shouldn't happen, as fetch and reveal have already been triggered
-          throw RangeError.index(index, this);
-        case PageMode.paginated:
-          item = _latestItem;
-          _triggerFetch();
-      }
-    }
-    _latestItem = item;
-    return item;
+
+    // Controller case with strategy
+    return _convert(_strategy!.getItemAt(index));
+
+  }
+
+  void markSeen(int index, {bool force = false}) {
+    if (posts != null) return;
+    _strategy?.markSeen(index, force: force);
+  }
+
+  void dispose() {
+    _strategy?.dispose();
+    dynlen.dispose();
+  }
+}
+
+// ========== Infinite Strategy (exact replica of original logic) ==========
+class _InfiniteStrategy implements _ListingStrategy {
+  _InfiniteStrategy(this.gridController, this.length);
+
+  final PostGridController<dynamic> gridController;
+  Set<int> seenIndices = {};
+  var indexOffset = 0;
+  var fetchPending = false;
+  int get seenLength => seenIndices.length + indexOffset;
+  @override
+  final ValueNotifier<int> length;
+
+
+  @override
+  dynamic getItemAt(int index) {
+    // The infinite strategy relies on the controller's items directly.
+    // No additional caching; just fetch from controller.
+    return gridController.items.elementAtOrNull(index);
   }
 
   @override
-  List<T> toList({bool growable = false}) {
-    throw UnsupportedError('DetailsPostsListing cannot be cast to list'); 
-  }
-
-
   void markSeen(int index, {bool force = false}) {
-    // Only track indices that belong to the *current* fetch cycle.
-    if (gridController == null) return;
-    if (index < _pagination.indexOffset) return;
+    if (index < indexOffset) return;
 
     if (force) {
-      // force mark all previous ones as seen
-      _pagination.indexOffset = index;
-      _pagination.seenIndices.clear();
+      indexOffset = index;
+      seenIndices.clear();
     } else {
-      _pagination.seenIndices.add(index);
+      seenIndices.add(index);
     }
 
-    // Trigger a background fetch when ≥ 3/4 of visible items accessed
-    final visible = dynlen.value;
-    switch (gridController!.pageMode) {
-      case PageMode.infinite:
-        if (visible > 0 &&
-          _pagination.seenLength >= (visible * 3 / 4).ceil() &&
-          !_pagination.fetchPending &&
-          gridController!.hasMore &&
-          !gridController!.loading &&
-          !gridController!.refreshing) {
-            _triggerFetch();
-        }
-        
-        final currentItemCount = gridController!.items.length;
-        final isLastVisible = _pagination.seenLength >= visible;
+    final visible = length.value;
+    if (visible > 0 &&
+        seenLength >= (visible * 3 / 4).ceil() &&
+        !fetchPending &&
+        gridController.hasMore &&
+        !gridController.loading &&
+        !gridController.refreshing) {
+      _triggerFetch();
+    }
 
-        if (isLastVisible && currentItemCount > visible) {
-          _reveal(currentItemCount);
-        }
-      case PageMode.paginated:
-        if (index == length-1) {
-          _triggerFetch();
-        }
+    final isLastVisible = seenLength >= visible - 1;
+
+    final currentItemCount = gridController.items.length;
+    if (isLastVisible && currentItemCount > visible) {
+      _reveal(currentItemCount);
     }
   }
 
   Future<void> _triggerFetch() async {
-    if (!gridController!.hasMore) return;
-    _pagination.fetchPending = true;
-    switch (gridController!.pageMode) {
-      case PageMode.infinite:
-        await gridController!.fetchMore();
-      case PageMode.paginated:
-        await gridController!.goToNextPage();
-    }
+    if (!gridController.hasMore) return;
+    fetchPending = true;
+    await gridController.fetchMore();
   }
 
-  // ValueNotifier handler for PostGridController posts
-  void _onItemsUpdated() {
-    if (gridController == null) return;
-    if (gridController!.items.isEmpty) return;
-    _pagination.fetchPending = false;
-    switch (gridController!.pageMode) {
-      case PageMode.paginated:
-        // when paginating, jump to next page immediately
-        _reveal(gridController!.items.length);
-    
-      case PageMode.infinite:
-        // infinite only reveals when all seen
-    }
-  }
-
-  // reveal new items depending on criteria
   void _reveal(int newLength) {
-    if (gridController!.items.isEmpty) return;
-    switch (gridController!.pageMode) {
-      case PageMode.paginated:
-        // Completely new set of items → reset offset to zero.
-        _pagination.indexOffset = 0;
-      case PageMode.infinite:
-        // Existing items are preserved; offset by previous visible count.
-        _pagination.indexOffset = dynlen.value;
-    }
-
-    _pagination.seenIndices.clear();
-    dynlen.value = newLength;
+    indexOffset = length.value;
+    fetchPending = false;
+    seenIndices.clear();
+    length.value = newLength;
   }
 
+
+  @override
   void dispose() {
-    gridController?.itemsNotifier.removeListener(_onItemsUpdated);
-    dynlen.dispose();
   }
+  
+
 }
+
+// // ========== Paginated Strategy (sliding‑window cache) ==========
+// class _PaginatedStrategy implements _ListingStrategy {
+//   _PaginatedStrategy(this.gridController) {
+//     gridController.itemsNotifier.addListener(onItemsUpdated);
+//     gridController.pageNotifier.addListener(_onPageChanged);
+
+//     _currentControllerPage = gridController.page;
+//     if (gridController.items.isNotEmpty) {
+//       _pageCache[_currentControllerPage] = List.from(gridController.items);
+//     }
+//   }
+
+//   final PostGridController<dynamic> gridController;
+//   void Function(int) _updateLength = (l) => ();
+
+//   final Map<int, List<dynamic>> _pageCache = {};
+//   var _baseOffset = 0;
+//   var _currentControllerPage = 1;
+//   var _isLoadingPage = false;
+
+
+//   void _onPageChanged() {
+//     _currentControllerPage = gridController.page;
+//   }
+
+//   List<int> get _sortedPages => _pageCache.keys.toList()..sort();
+//   int get _cachedLength => _sortedPages.fold(0, (sum, p) => sum + _pageCache[p]!.length);
+
+//   @override
+//   int get length => _baseOffset + _cachedLength;
+
+
+//   @override
+//   dynamic? getItemAt(int index) {
+//     var runningOffset = _baseOffset;
+//     for (final page in _sortedPages) {
+//       final pageItems = _pageCache[page]!;
+//       if (index >= runningOffset && index < runningOffset + pageItems.length) {
+//         final localIndex = index - runningOffset;
+//         _prefetchIfNeeded(page, localIndex, pageItems.length);
+//         return pageItems[localIndex];
+//       }
+//       runningOffset += pageItems.length;
+//     }
+
+//     // Not in cache – determine direction
+//     int targetPage;
+//     if (_pageCache.isEmpty) {
+//       targetPage = 1;
+//     } else if (index < _baseOffset) {
+//       targetPage = _sortedPages.first - 1;   // need older page
+//     } else {
+//       targetPage = _sortedPages.last + 1;    // need newer page
+//     }
+
+//     Future.microtask(() => _loadPageIfNeeded(targetPage));
+//     return null;
+//   }
+
+//   void _prefetchIfNeeded(int page, int localIndex, int pageLength) {
+//     // Prefetch next page when near the end of current page
+//     if (localIndex >= pageLength - 2) {
+//       _loadPageIfNeeded(page + 1);
+//     }
+//     // Prefetch previous page when near the beginning (and not on first page)
+//     if (localIndex <= 1 && page > 1) {
+//       _loadPageIfNeeded(page - 1);
+//     }
+//   }
+
+//   Future<void> _loadPageIfNeeded(int page) async {
+//     if (_isLoadingPage) return;
+//     if (_pageCache.containsKey(page)) return;
+//     if (page < 1) return;
+
+//     _isLoadingPage = true;
+//     unawaited(Future.microtask(() async {
+//       try {
+//         // Snapshot current page before jumping away
+//         final currentPage = _currentControllerPage;
+//         if (gridController.items.isNotEmpty && !_pageCache.containsKey(currentPage)) {
+//           _addPageToCache(currentPage, List.from(gridController.items));
+//         }
+
+//         await gridController.jumpToPage(page);
+
+//         // Cache the newly loaded page
+//         if (gridController.items.isNotEmpty) {
+//           _addPageToCache(page, List.from(gridController.items));
+//         }
+
+//         _evictDistantPages(page);
+//         _updateLength(length);
+//       } finally {
+//         _isLoadingPage = false;
+//       }
+//     }));
+//   }
+
+//   void _addPageToCache(int page, List<dynamic> items) {
+//     final wasEmpty = _pageCache.isEmpty;
+//     final oldOldest = wasEmpty ? null : _sortedPages.first;
+
+//     _pageCache[page] = items;
+
+//     if (!wasEmpty && page < oldOldest!) {
+//       // New page is older than previous oldest → it is now cached,
+//       // so its items are no longer "evicted". Subtract from baseOffset.
+//       _baseOffset -= items.length;
+//     }
+//   }
+
+//   void _evictDistantPages(int centerPage) {
+//     final pagesToRemove = _pageCache.keys.where((p) => (p - centerPage).abs() > 1).toList();
+//     if (pagesToRemove.isEmpty) return;
+
+//     pagesToRemove.sort();
+//     for (final page in pagesToRemove) {
+//       if (page == _sortedPages.first) {
+//         // This is the oldest page in cache; it's being evicted.
+//         // Add its length to baseOffset.
+//         _baseOffset += _pageCache[page]!.length;
+//       }
+//       _pageCache.remove(page);
+//     }
+//   }
+
+//   @override
+//   void markSeen(int index, {bool force = false}) {
+//     getItemAt(index); // just ensure the page is loaded
+//   }
+
+
+//   @override
+//   void dispose() {
+//     gridController.itemsNotifier.removeListener(onItemsUpdated);
+//     gridController.pageNotifier.removeListener(_onPageChanged);
+//     _pageCache.clear();
+//   }
+// }
+
 
 class DetailsRouteContext<T extends Post> extends Equatable {
   DetailsRouteContext({

--- a/lib/core/posts/details/src/routes/details_route_context.dart
+++ b/lib/core/posts/details/src/routes/details_route_context.dart
@@ -1,13 +1,205 @@
 // Package imports:
+import 'dart:collection';
+
 import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
 // Project imports:
 import '../../../../configs/config/types.dart';
+import '../../../listing/providers.dart';
+import '../../../listing/types.dart';
 import '../../../post/types.dart';
 
+class _PaginationState {
+  /// A set tracking which indices (larger than indexOffset) have been accessed
+  final Set<int> seenIndices = {};
+  /// All indices below this offset were seen in a previous fetch cycle
+  /// and must not be re-added to [seenIndices].
+  var indexOffset = 0;
+
+  /// Whether we have dispatched a fetchMore call that hasn't been
+  /// reflected in a new reveal yet.
+  var fetchPending = false;
+  int get seenLength => seenIndices.length + indexOffset;
+}
+
+class DetailsPostsListing<T extends Post> extends ListBase<T> {
+  /// instantiate a version of this which handles a handles a static list
+  DetailsPostsListing.list({ required List<T> this.posts}):
+        gridController = null,
+        _getItem = ((index) => posts[index]),
+        _pagination = _PaginationState(),
+        dynlen = ValueNotifier<int>(posts.length);
+
+  /// instatiate a version of this which handles a controller. This should be preferred where possible.
+  DetailsPostsListing.controller({required PostGridController<dynamic> controller}):
+        gridController = controller,
+        posts = null,
+        _getItem = ((index) => controller.items.elementAtOrNull(index)),
+        _pagination = _PaginationState(),
+        dynlen = ValueNotifier<int>(controller.items.length) {
+    gridController!.itemsNotifier.addListener(_onItemsUpdated);
+  }
+   // shared-state constructor
+  DetailsPostsListing._shared(DetailsPostsListing<dynamic> source, this._getItem):
+        gridController = source.gridController,
+        posts = source.posts,
+        dynlen = source.dynlen,
+        _pagination = source._pagination;
+
+  final List<dynamic>? posts;
+  final PostGridController<dynamic>? gridController;
+  final ValueNotifier<int> dynlen;
+  final T? Function(int index) _getItem;
+
+  // --- pagination state ---
+  final _PaginationState _pagination;
+
+  DetailsPostsListing<T2> listingMap<T2 extends Post>(T2 Function(T) converter) {
+    return DetailsPostsListing<T2>._shared(
+      this,
+      (index) => converter(this[index]),
+    );
+  }
+  
+  // ignore: avoid_setters_without_getters
+  set initial(int intialIndex) => _pagination.indexOffset = intialIndex;
+
+  @override
+  int get length => dynlen.value;
+
+  @override
+  set length(int _) {
+    // ListBase requires this to be implemented; mutations are not
+    // supported for the controller case.
+    throw UnsupportedError('DetailsPostsListing is read-only');
+  }
+
+  @override
+  void operator []=(int index, T value) {
+    throw UnsupportedError('DetailsPostsListing is read-only');
+  }
+  
+
+  // hacky way to ensure paginated mode doesn't break
+  late T _latestItem;
+  @override
+  T operator [](int index) {
+    if (index == 1 || index == 2 || index == 3) {
+      return _latestItem;
+    }
+    var item = _getItem(index);
+    
+    if (item == null){
+      switch (gridController!.pageMode) {
+        case PageMode.infinite:
+          // this shouldn't happen, as fetch and reveal have already been triggered
+          throw RangeError.index(index, this);
+        case PageMode.paginated:
+          item = _latestItem;
+          _triggerFetch();
+      }
+    }
+    _latestItem = item;
+    return item;
+  }
+
+  @override
+  List<T> toList({bool growable = false}) {
+    throw UnsupportedError('DetailsPostsListing cannot be cast to list'); 
+  }
+
+
+  void markSeen(int index, {bool force = false}) {
+    // Only track indices that belong to the *current* fetch cycle.
+    if (gridController == null) return;
+    if (index < _pagination.indexOffset) return;
+
+    if (force) {
+      // force mark all previous ones as seen
+      _pagination.indexOffset = index;
+      _pagination.seenIndices.clear();
+    } else {
+      _pagination.seenIndices.add(index);
+    }
+
+    // Trigger a background fetch when ≥ 3/4 of visible items accessed
+    final visible = dynlen.value;
+    switch (gridController!.pageMode) {
+      case PageMode.infinite:
+        if (visible > 0 &&
+          _pagination.seenLength >= (visible * 3 / 4).ceil() &&
+          !_pagination.fetchPending &&
+          gridController!.hasMore &&
+          !gridController!.loading &&
+          !gridController!.refreshing) {
+            _triggerFetch();
+        }
+        
+        final currentItemCount = gridController!.items.length;
+        final isLastVisible = _pagination.seenLength >= visible;
+
+        if (isLastVisible && currentItemCount > visible) {
+          _reveal(currentItemCount);
+        }
+      case PageMode.paginated:
+        if (index == length-1) {
+          _triggerFetch();
+        }
+    }
+  }
+
+  Future<void> _triggerFetch() async {
+    if (!gridController!.hasMore) return;
+    _pagination.fetchPending = true;
+    switch (gridController!.pageMode) {
+      case PageMode.infinite:
+        await gridController!.fetchMore();
+      case PageMode.paginated:
+        await gridController!.goToNextPage();
+    }
+  }
+
+  // ValueNotifier handler for PostGridController posts
+  void _onItemsUpdated() {
+    if (gridController == null) return;
+    if (gridController!.items.isEmpty) return;
+    _pagination.fetchPending = false;
+    switch (gridController!.pageMode) {
+      case PageMode.paginated:
+        // when paginating, jump to next page immediately
+        _reveal(gridController!.items.length);
+    
+      case PageMode.infinite:
+        // infinite only reveals when all seen
+    }
+  }
+
+  // reveal new items depending on criteria
+  void _reveal(int newLength) {
+    if (gridController!.items.isEmpty) return;
+    switch (gridController!.pageMode) {
+      case PageMode.paginated:
+        // Completely new set of items → reset offset to zero.
+        _pagination.indexOffset = 0;
+      case PageMode.infinite:
+        // Existing items are preserved; offset by previous visible count.
+        _pagination.indexOffset = dynlen.value;
+    }
+
+    _pagination.seenIndices.clear();
+    dynlen.value = newLength;
+  }
+
+  void dispose() {
+    gridController?.itemsNotifier.removeListener(_onItemsUpdated);
+    dynlen.dispose();
+  }
+}
+
 class DetailsRouteContext<T extends Post> extends Equatable {
-  const DetailsRouteContext({
+  DetailsRouteContext({
     required this.initialIndex,
     required this.posts,
     required this.scrollController,
@@ -16,7 +208,9 @@ class DetailsRouteContext<T extends Post> extends Equatable {
     required this.initialThumbnailUrl,
     required this.configSearch,
     this.dislclaimer,
-  });
+  }){
+    posts.initial = initialIndex;
+  }
 
   DetailsRouteContext<T> copyWith({
     int? initialIndex,
@@ -36,7 +230,7 @@ class DetailsRouteContext<T extends Post> extends Equatable {
   }
 
   final int initialIndex;
-  final List<T> posts;
+  final DetailsPostsListing<T> posts;
   final AutoScrollController? scrollController;
   final bool isDesktop;
   final bool hero;

--- a/lib/core/posts/details/src/routes/route_utils.dart
+++ b/lib/core/posts/details/src/routes/route_utils.dart
@@ -12,7 +12,7 @@ import 'details_route_context.dart';
 
 void goToPostDetailsPageFromPosts<T extends Post>({
   required WidgetRef ref,
-  required List<T> posts,
+  required DetailsPostsListing<T> posts,
   required int initialIndex,
   required String? initialThumbnailUrl,
   AutoScrollController? scrollController,
@@ -33,7 +33,7 @@ void goToPostDetailsPageFromController<T extends Post>({
   AutoScrollController? scrollController,
 }) => goToPostDetailsPageCore(
   ref: ref,
-  posts: controller.items.toList(),
+  posts: DetailsPostsListing.controller(controller: controller),
   initialIndex: initialIndex,
   scrollController: scrollController,
   initialThumbnailUrl: initialThumbnailUrl,
@@ -42,7 +42,7 @@ void goToPostDetailsPageFromController<T extends Post>({
 
 void goToPostDetailsPageCore<T extends Post>({
   required WidgetRef ref,
-  required List<T> posts,
+  required DetailsPostsListing<T> posts,
   required int initialIndex,
   required bool hero,
   required String? initialThumbnailUrl,
@@ -75,8 +75,7 @@ void goToSinglePostDetailsPage<T extends Post>({
     ).toString(),
     extra: DetailsRouteContext(
       initialIndex: 0,
-      // ignore: prefer_const_literals_to_create_immutables
-      posts: <T>[],
+      posts: DetailsPostsListing.list(posts: <T>[]),
       scrollController: null,
       isDesktop: ref.context.isLargeScreen,
       hero: false,

--- a/lib/core/posts/details/src/routes/routes.dart
+++ b/lib/core/posts/details/src/routes/routes.dart
@@ -150,7 +150,7 @@ class PostDetailsDataLoadingTransitionPage extends ConsumerWidget {
 
             final detailsContext = DetailsRouteContext(
               initialIndex: 0,
-              posts: [post],
+              posts: DetailsPostsListing.list(posts: [post]),
               scrollController: null,
               isDesktop: false,
               hero: false,

--- a/lib/core/posts/details/src/types/post_details.dart
+++ b/lib/core/posts/details/src/types/post_details.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../../settings/types.dart';
 import '../../../post/types.dart';
 import '../../../slideshow/types.dart';
+import '../routes/details_route_context.dart';
 import '../widgets/post_details_controller.dart';
 
 class PostDetailsData<T extends Post> {
@@ -13,7 +14,7 @@ class PostDetailsData<T extends Post> {
     required this.controller,
   });
 
-  final List<T> posts;
+  final DetailsPostsListing<T> posts;
   final PostDetailsController<T> controller;
 }
 

--- a/lib/core/posts/details/src/widgets/post_details_controller.dart
+++ b/lib/core/posts/details/src/widgets/post_details_controller.dart
@@ -11,7 +11,6 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 // Project imports:
 import '../../../../videos/engines/types.dart';
 import '../../../../videos/player/types.dart';
-import '../../../listing/providers.dart';
 import '../../../post/types.dart';
 import '../../routes.dart';
 

--- a/lib/core/posts/details/src/widgets/post_details_controller.dart
+++ b/lib/core/posts/details/src/widgets/post_details_controller.dart
@@ -31,7 +31,6 @@ class PostDetailsController<T extends Post> extends ChangeNotifier {
     required this.reduceAnimations,
     required this.dislclaimer,
     required this.doubleTapSeekDuration,
-    this.controller,
   }) : currentPage = ValueNotifier(initialPage),
        _initialPage = initialPage,
        currentPost = ValueNotifier(posts[initialPage]),
@@ -44,7 +43,6 @@ class PostDetailsController<T extends Post> extends ChangeNotifier {
   final String? initialThumbnailUrl;
   final String? dislclaimer;
   final int doubleTapSeekDuration;
-  final PostGridController<T>? controller;
 
 
   late ValueNotifier<int?> currentSettledPage;

--- a/lib/core/posts/details/src/widgets/post_details_controller.dart
+++ b/lib/core/posts/details/src/widgets/post_details_controller.dart
@@ -11,7 +11,9 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 // Project imports:
 import '../../../../videos/engines/types.dart';
 import '../../../../videos/player/types.dart';
+import '../../../listing/providers.dart';
 import '../../../post/types.dart';
+import '../../routes.dart';
 
 const kSeekAnimationDuration = Duration(milliseconds: 400);
 const kPlayPauseAnimationDuration = Duration(milliseconds: 700);
@@ -29,6 +31,7 @@ class PostDetailsController<T extends Post> extends ChangeNotifier {
     required this.reduceAnimations,
     required this.dislclaimer,
     required this.doubleTapSeekDuration,
+    this.controller,
   }) : currentPage = ValueNotifier(initialPage),
        _initialPage = initialPage,
        currentPost = ValueNotifier(posts[initialPage]),
@@ -36,11 +39,13 @@ class PostDetailsController<T extends Post> extends ChangeNotifier {
        currentSettledPage = ValueNotifier(null);
   final AutoScrollController? scrollController;
   final bool reduceAnimations;
-  final List<T> posts;
+  final DetailsPostsListing<T> posts;
   final int _initialPage;
   final String? initialThumbnailUrl;
   final String? dislclaimer;
   final int doubleTapSeekDuration;
+  final PostGridController<T>? controller;
+
 
   late ValueNotifier<int?> currentSettledPage;
   late ValueNotifier<int> currentPage;

--- a/lib/core/posts/details/src/widgets/post_details_image_preloader.dart
+++ b/lib/core/posts/details/src/widgets/post_details_image_preloader.dart
@@ -12,6 +12,7 @@ import '../../../listing/providers.dart';
 import '../../../media_preload/providers.dart';
 import '../../../media_preload/types.dart';
 import '../../../post/types.dart';
+import '../../routes.dart';
 import 'post_details_page_view_scope.dart';
 
 class PostDetailsImagePreloader<T extends Post> extends ConsumerStatefulWidget {
@@ -24,7 +25,7 @@ class PostDetailsImagePreloader<T extends Post> extends ConsumerStatefulWidget {
   });
 
   final BooruConfigAuth authConfig;
-  final List<T> posts;
+  final DetailsPostsListing<T> posts;
   final Widget child;
   final String Function(T post) imageUrlBuilder;
 

--- a/lib/core/posts/details/src/widgets/post_details_page_scaffold.dart
+++ b/lib/core/posts/details/src/widgets/post_details_page_scaffold.dart
@@ -103,6 +103,7 @@ class _PostDetailPageScaffoldState<T extends Post>
       widget.controller.onPageSettled(
         widget.controller.initialPage,
       );
+      _posts.setPostDetailsPageViewController(_controller);
     });
 
     widget.controller.isVideoPlaying.addListener(_isVideoPlayingChanged);

--- a/lib/core/posts/details/src/widgets/post_details_page_scaffold.dart
+++ b/lib/core/posts/details/src/widgets/post_details_page_scaffold.dart
@@ -28,6 +28,7 @@ import '../../../details_pageview/widgets.dart';
 import '../../../details_parts/types.dart';
 import '../../../post/routes.dart';
 import '../../../post/types.dart';
+import '../../routes.dart';
 import '../types/post_details.dart';
 import '../types/post_details_swipe_mode.dart';
 import 'post_details_controller.dart';
@@ -56,7 +57,7 @@ class PostDetailsPageScaffold<T extends Post> extends ConsumerStatefulWidget {
     this.preferredPreviewParts,
   });
 
-  final List<T> posts;
+  final DetailsPostsListing<T> posts;
   final void Function()? onExpanded;
   final PostDetailsController<T> controller;
   final PostDetailsUIBuilder? uiBuilder;
@@ -89,7 +90,7 @@ class _PostDetailPageScaffoldState<T extends Post>
   ValueNotifier<bool> visibilityNotifier = ValueNotifier(false);
   late final _isInitPage = widget.isInitPage;
 
-  List<T> get posts => _posts;
+  DetailsPostsListing<T> get posts => _posts;
 
   @override
   void initState() {
@@ -113,7 +114,7 @@ class _PostDetailPageScaffoldState<T extends Post>
 
     _volumeKeyPageNavigator ??= VolumeKeyPageNavigator(
       pageViewController: _controller,
-      totalPosts: _posts.length,
+      totalPosts: _posts.length, // FIXME: use _posts.dynlen notifier for when more posts get loaded
       visibilityNotifier: visibilityNotifier,
       enableVolumeKeyViewerNavigation: () => ref.read(
         settingsProvider.select((value) => value.volumeKeyViewerNavigation),
@@ -128,7 +129,7 @@ class _PostDetailPageScaffoldState<T extends Post>
     _volumeKeyPageNavigator?.dispose();
     widget.controller.isVideoPlaying.removeListener(_isVideoPlayingChanged);
     _controller.precisePage.removeListener(_onPrecisePageChanged);
-
+    widget.controller.posts.dispose();
     super.dispose();
   }
 
@@ -291,7 +292,8 @@ class _PostDetailPageScaffoldState<T extends Post>
           final post = posts[page];
 
           widget.controller.setPage(page);
-
+          final slideshowRunning = _pageViewController?.slideshowController.isRunning ?? false;
+          posts.markSeen(page, force: !slideshowRunning);
           _isInitPage.value = false;
 
           if (_controller.overlay.value) {
@@ -314,7 +316,7 @@ class _PostDetailPageScaffoldState<T extends Post>
         onExit: () {
           widget.controller.onExit();
         },
-        itemCount: posts.length,
+        itemCountNotifier: posts.dynlen,
         leftActions: [
           CircularIconButton(
             icon: const Icon(

--- a/lib/core/posts/details/src/widgets/post_details_scope.dart
+++ b/lib/core/posts/details/src/widgets/post_details_scope.dart
@@ -10,6 +10,7 @@ import '../../../../../foundation/display.dart';
 import '../../../../settings/providers.dart';
 import '../../../details_pageview/widgets.dart';
 import '../../../post/types.dart';
+import '../routes/details_route_context.dart';
 import '../types/inherited_post.dart';
 import '../types/post_details.dart';
 import 'post_details_controller.dart';
@@ -28,7 +29,7 @@ class PostDetailsScope<T extends Post> extends ConsumerStatefulWidget {
 
   final int initialIndex;
   final String? initialThumbnailUrl;
-  final List<T> posts;
+  final DetailsPostsListing<T> posts;
   final String? dislclaimer;
   final AutoScrollController? scrollController;
   final Widget child;
@@ -72,7 +73,7 @@ class _PostDetailsLayoutSwitcherState<T extends Post>
       slideshowOptions: slideshowOptions,
       hoverToControlOverlay: hoverToControlOverlay,
       checkIfLargeScreen: () => context.isLargeScreen,
-      totalPage: widget.posts.length,
+      totalPagesNotifier: widget.posts.dynlen,
       disableAnimation: reduceAnimations,
       onBeforeSlideshowAdvance: (currentPage, nextPage) async {
         if (viewerSettings.slideshowVideoBehavior.isWaitForCompletion) {

--- a/lib/core/posts/details_pageview/src/post_details_page_view.dart
+++ b/lib/core/posts/details_pageview/src/post_details_page_view.dart
@@ -34,7 +34,7 @@ enum ViewMode {
 class PostDetailsPageView extends StatefulWidget {
   const PostDetailsPageView({
     required this.sheetBuilder,
-    required this.itemCount,
+    required this.itemCountNotifier,
     required this.itemBuilder,
     required this.checkIfLargeScreen,
     super.key,
@@ -57,7 +57,7 @@ class PostDetailsPageView extends StatefulWidget {
 
   final Widget Function(BuildContext, ScrollController? scrollController)
   sheetBuilder;
-  final int itemCount;
+  final ValueNotifier<int> itemCountNotifier;
   final IndexedWidgetBuilder itemBuilder;
   final double maxSize;
   final double swipeDownThreshold;
@@ -172,7 +172,7 @@ class _PostDetailsPageViewState extends State<PostDetailsPageView>
         PostDetailsPageViewController(
           initialPage: 0,
           checkIfLargeScreen: widget.checkIfLargeScreen,
-          totalPage: widget.itemCount,
+          totalPagesNotifier: widget.itemCountNotifier,
           viewMode: widget.viewMode,
         );
 
@@ -547,25 +547,31 @@ class _PostDetailsPageViewState extends State<PostDetailsPageView>
     final isPortrait = !context.isLargeScreen;
 
     return ValueListenableBuilder(
-      valueListenable: _controller.sheetState,
-      builder: (_, state, _) {
-        final blockSwipe = !swipe || state.isExpanded || interacting;
+      valueListenable: widget.itemCountNotifier,
+      builder: (_, _, _) {
+      return ValueListenableBuilder(
+        valueListenable: _controller.sheetState,
+        builder: (_, state, _) {
+          final blockSwipe = !swipe || state.isExpanded || interacting;
 
-        return PageView.builder(
-          scrollDirection: useVerticalLayout ? Axis.vertical : Axis.horizontal,
-          onPageChanged: blockSwipe && !isPortrait
-              ? (_) => _controller.startCooldownTimer()
-              : null,
-          controller: _controller.pageController,
-          physics: blockSwipe
-              ? const NeverScrollableScrollPhysics()
-              : const _PostDetailsPagePhysics(),
-          itemCount: widget.itemCount,
-          itemBuilder: (context, index) => _buildItem(index, blockSwipe),
-        );
-      },
-    );
+          return PageView.builder(
+            scrollDirection: useVerticalLayout ? Axis.vertical : Axis.horizontal,
+            onPageChanged: blockSwipe && !isPortrait
+                ? (_) => _controller.startCooldownTimer()
+                : null,
+            controller: _controller.pageController,
+            physics: blockSwipe
+                ? const NeverScrollableScrollPhysics()
+                : const _PostDetailsPagePhysics(),
+            itemCount: widget.itemCountNotifier.value,
+            itemBuilder: (context, index) => _buildItem(index, blockSwipe),
+          );
+        },
+      );
+    }
+  );
   }
+  
 
   final _dummyAlwaysFalse = ValueNotifier(false);
 
@@ -574,16 +580,21 @@ class _PostDetailsPageViewState extends State<PostDetailsPageView>
       final isVertical = useVerticalLayout;
 
       return [
-        PageNavButton(
-          alignment: isVertical
-              ? Alignment.bottomCenter
-              : Alignment.centerRight,
-          controller: _controller,
-          visibleWhen: (page) => page < widget.itemCount - 1,
-          icon: Icon(
-            isVertical ? Symbols.keyboard_arrow_down : Symbols.arrow_forward,
-          ),
-          onPressed: () => _controller.nextPage(duration: Duration.zero),
+        ValueListenableBuilder<int>(
+          valueListenable: widget.itemCountNotifier,
+          builder: (context, itemCount, _) {
+            return PageNavButton(
+              alignment: isVertical
+                  ? Alignment.bottomCenter
+                  : Alignment.centerRight,
+              controller: _controller,
+              visibleWhen: (page) => page < itemCount - 1,
+              icon: Icon(
+                isVertical ? Symbols.keyboard_arrow_down : Symbols.arrow_forward,
+              ),
+              onPressed: () => _controller.nextPage(duration: Duration.zero),
+            );
+          },
         ),
         PageNavButton(
           alignment: isVertical ? Alignment.topCenter : Alignment.centerLeft,

--- a/lib/core/posts/details_pageview/src/post_details_page_view_controller.dart
+++ b/lib/core/posts/details_pageview/src/post_details_page_view_controller.dart
@@ -17,7 +17,7 @@ import 'post_details_page_view.dart';
 class PostDetailsPageViewController extends ChangeNotifier {
   PostDetailsPageViewController({
     required this.initialPage,
-    required this.totalPage,
+    required this.totalPagesNotifier,
     required this.checkIfLargeScreen,
     this.disableAnimation = false,
     this.initialHideOverlay = false,
@@ -35,7 +35,7 @@ class PostDetailsPageViewController extends ChangeNotifier {
        _initialSlideshowOptions = slideshowOptions;
 
   final int initialPage;
-  final int totalPage;
+  final ValueNotifier<int> totalPagesNotifier;
   final bool initialHideOverlay;
   final double maxSize;
   final double thresholdSizeToExpand;
@@ -53,6 +53,7 @@ class PostDetailsPageViewController extends ChangeNotifier {
   final _sheetController = DraggableScrollableController();
   late final _slideshowController = SlideshowController(
     onNavigateToPage: createDefaultSlideshowNavigateCallback(_pageController),
+    totalPagesNotifier: totalPagesNotifier,
     options: _initialSlideshowOptions,
     onBeforeAdvance: onBeforeSlideshowAdvance,
   );
@@ -560,10 +561,7 @@ class PostDetailsPageViewController extends ChangeNotifier {
 
     hideAllUI();
 
-    _slideshowController.start(
-      page,
-      totalPage,
-    );
+    _slideshowController.start(page);
   }
 
   void stopSlideshow() {

--- a/lib/core/posts/details_parts/src/sliver_details_post_list.dart
+++ b/lib/core/posts/details_parts/src/sliver_details_post_list.dart
@@ -139,7 +139,7 @@ class SliverPreviewPostGrid<T extends Post> extends ConsumerWidget {
       isAI: post.isAI,
       onTap: () => goToPostDetailsPageFromPosts(
         ref: ref,
-        posts: posts,
+        posts: DetailsPostsListing.list(posts: posts),
         initialIndex: index,
         initialThumbnailUrl: post.thumbnailImageUrl,
       ),

--- a/lib/core/posts/explores/src/explore_page.dart
+++ b/lib/core/posts/explores/src/explore_page.dart
@@ -188,7 +188,7 @@ class ExploreList extends ConsumerWidget {
               child: GestureDetector(
                 onTap: () => goToPostDetailsPageFromPosts(
                   ref: ref,
-                  posts: filteredPosts,
+                  posts: DetailsPostsListing.list(posts: filteredPosts),
                   initialIndex: index,
                   initialThumbnailUrl: mediaUrlResolver.resolveMediaUrl(
                     post,

--- a/lib/core/posts/listing/src/widgets/post_grid_controller.dart
+++ b/lib/core/posts/listing/src/widgets/post_grid_controller.dart
@@ -295,7 +295,7 @@ class PostGridController<T extends Post> extends ChangeNotifier {
     _eventController.add(const PostControllerRefreshCompleted());
     notifyListeners();
   }
-
+  late Completer<void>? _fetchCompleter;
   // Loads more items
   Future<void> fetchMore({
     VoidCallback? onNoMoreData,
@@ -307,24 +307,30 @@ class PostGridController<T extends Post> extends ChangeNotifier {
     }
 
     _debounceTimer?.cancel();
+    _fetchCompleter = Completer<void>();  
     _debounceTimer = Timer(debounceDuration, () async {
-      _loading = true;
-      if (_pageMode == PageMode.infinite) {
-        _setPage(_page + 1);
-      }
-      notifyListeners();
+      try {
+        _loading = true;
+        if (_pageMode == PageMode.infinite) {
+          _setPage(_page + 1);
+        }
+        notifyListeners();
 
-      final newItems = await _fetchPosts(_page);
-      _hasMore = newItems.posts.isNotEmpty;
-      if (_hasMore) {
-        await _addAll(newItems.posts);
-      } else {
-        onNoMoreData?.call();
+        final newItems = await _fetchPosts(_page);
+        _hasMore = newItems.posts.isNotEmpty;
+        if (_hasMore) {
+          await _addAll(newItems.posts);
+        } else {
+          onNoMoreData?.call();
+        }
+        _loading = false;
+        count.value = newItems.total;
+        notifyListeners();
+      } finally {
+        _fetchCompleter!.complete();
       }
-      _loading = false;
-      count.value = newItems.total;
-      notifyListeners();
     });
+    return _fetchCompleter!.future; // allow awaiting the fetchMore completion
   }
 
   // Jump to a specific page without knowing the total pages and allowing page skips

--- a/lib/core/posts/slideshow/src/slideshow_controller.dart
+++ b/lib/core/posts/slideshow/src/slideshow_controller.dart
@@ -169,10 +169,11 @@ class SlideshowController {
     final currentState = _state.value;
     final newState = currentState.withUpdatedTotalPages(newTotalPages);
 
-    // If we have a new current page due to total gettign smaller, trigger navigation to sync UI.
+    // If we have a new current page due to total getting smaller, trigger navigation to sync UI.
     if (newState.currentPage != currentState.currentPage) {
       // Navigate without animation (skip animation)
       onNavigateToPage(newState.currentPage, true);
     }
+    _state.value = newState;
   }
 }

--- a/lib/core/posts/slideshow/src/slideshow_controller.dart
+++ b/lib/core/posts/slideshow/src/slideshow_controller.dart
@@ -53,25 +53,36 @@ SlideshowNavigateCallback createDefaultSlideshowNavigateCallback(
 class SlideshowController {
   SlideshowController({
     required this.onNavigateToPage,
+    required ValueNotifier<int> totalPagesNotifier,
     this.options = const SlideshowOptions(),
     this.onBeforeAdvance,
     TimerFactory? createTimer,
-  }) : _state = ValueNotifier(const SlideshowState.idle()),
-       _createTimer = createTimer ?? Timer.new;
+  })  : _totalPagesNotifier = totalPagesNotifier,
+        _state = ValueNotifier(const SlideshowState.idle()),
+        _createTimer = createTimer ?? Timer.new {
+    _totalPagesListener = () => _handleTotalPagesChanged(totalPagesNotifier.value);
+    totalPagesNotifier.addListener(_totalPagesListener);
+  }
 
   final SlideshowAdvanceCallback? onBeforeAdvance;
   final SlideshowNavigateCallback onNavigateToPage;
   final TimerFactory _createTimer;
   SlideshowOptions options;
 
+  final ValueNotifier<int> _totalPagesNotifier;
   final ValueNotifier<SlideshowState> _state;
   Timer? _timer;
   var _skipOnBeforeAdvance = false;
+  late final VoidCallback _totalPagesListener;
 
   ValueListenable<SlideshowState> get state => _state;
   bool get isRunning => _state.value.isRunning;
 
-  void start(int startPage, int totalPages) {
+  void start(int startPage) {
+    final totalPages = _totalPagesNotifier.value;
+    assert(startPage >= 0 && startPage < totalPages,
+        'startPage must be in range [0, totalPages)');
+
     switch (_state.value) {
       case SlideshowRunning():
         return;
@@ -109,6 +120,7 @@ class SlideshowController {
   }
 
   void dispose() {
+    _totalPagesNotifier.removeListener(_totalPagesListener);
     _timer?.cancel();
     _state.dispose();
   }
@@ -126,9 +138,7 @@ class SlideshowController {
     switch (_state.value) {
       case SlideshowRunning() && final running:
         final nextState = running.advance();
-        final skipAnimation = running.shouldSkipAnimation(
-          options,
-        );
+        final skipAnimation = running.shouldSkipAnimation(options);
 
         if (!_skipOnBeforeAdvance) {
           await onBeforeAdvance?.call(
@@ -151,5 +161,18 @@ class SlideshowController {
 
   void _transitionTo(SlideshowState newState) {
     _state.value = newState;
+  }
+
+  void _handleTotalPagesChanged(int newTotalPages) {
+    assert(newTotalPages > 0, 'totalPages must never be zero');
+
+    final currentState = _state.value;
+    final newState = currentState.withUpdatedTotalPages(newTotalPages);
+
+    // If we have a new current page due to total gettign smaller, trigger navigation to sync UI.
+    if (newState.currentPage != currentState.currentPage) {
+      // Navigate without animation (skip animation)
+      onNavigateToPage(newState.currentPage, true);
+    }
   }
 }

--- a/lib/core/posts/slideshow/src/slideshow_state.dart
+++ b/lib/core/posts/slideshow/src/slideshow_state.dart
@@ -1,7 +1,6 @@
 // Project imports:
 import 'slideshow_direction.dart';
 import 'slideshow_options.dart';
-
 sealed class SlideshowState {
   const SlideshowState();
 
@@ -42,6 +41,60 @@ sealed class SlideshowState {
     SlideshowPaused(:final currentPage) => currentPage,
     _ => 0,
   };
+
+  SlideshowState withUpdatedTotalPages(int newTotalPages) => switch (this) {
+    // ignore: prefer_final_locals
+    SlideshowRunning s=> s._withUpdatedTotalPages(newTotalPages),
+    // ignore: prefer_final_locals
+    SlideshowPaused s => s._withUpdatedTotalPages(newTotalPages),
+    SlideshowIdle() => this,
+  };
+
+  /// Common adjustment logic for [SlideshowRunning] and [SlideshowPaused].
+  static ({
+    int currentPage,
+    List<int>? randomSequence,
+    int randomIndex,
+  }) _adjustForTotalPagesChange({
+    required int oldTotalPages,
+    required int newTotalPages,
+    required int currentPage,
+    List<int>? randomSequence,
+    required int randomIndex,
+  }) {
+
+    // Clamp current page to new bounds
+    final newCurrentPage = currentPage >= newTotalPages
+        ? newTotalPages - 1
+        : currentPage;
+
+    var newSequence = randomSequence;
+
+    if (randomSequence != null) {
+      if (newTotalPages > oldTotalPages) {
+        // Append newly added pages shuffled
+        final newPages = List.generate(
+          newTotalPages - oldTotalPages,
+          (i) => oldTotalPages + i,
+        )..shuffle();
+        newSequence = [...randomSequence, ...newPages];
+      } else if (newTotalPages < oldTotalPages) {
+        // Remove any pages beyond the new total
+        newSequence = randomSequence.where((p) => p < newTotalPages).toList();
+      }
+    }
+
+    var newRandomIndex = randomIndex;
+    if (newSequence != null && randomIndex >= newSequence.length) {
+      newRandomIndex = newSequence.length - 1;
+    }
+
+    return (
+      currentPage: newCurrentPage,
+      randomSequence: newSequence,
+      randomIndex: newRandomIndex,
+    );
+  }
 }
 
 final class SlideshowIdle extends SlideshowState {
@@ -95,11 +148,8 @@ final class SlideshowRunning extends SlideshowState {
         ? (randomIndex + 1) % (randomSequence?.length ?? 1)
         : randomIndex;
 
-    return SlideshowRunning(
+    return copyWith(
       currentPage: nextPage,
-      totalPages: totalPages,
-      direction: direction,
-      randomSequence: randomSequence,
       randomIndex: newRandomIndex,
     );
   }
@@ -107,7 +157,7 @@ final class SlideshowRunning extends SlideshowState {
   int _calculateNextPage() {
     return switch (direction) {
       SlideshowDirection.forward => (currentPage + 1) % totalPages,
-      SlideshowDirection.backward => (currentPage - 1) % totalPages,
+      SlideshowDirection.backward => (currentPage - 1 + totalPages) % totalPages,
       SlideshowDirection.random => _calculateRandomNextPage(),
     };
   }
@@ -138,6 +188,39 @@ final class SlideshowRunning extends SlideshowState {
       randomIndex: randomIndex,
     );
   }
+
+  SlideshowRunning copyWith({
+    int? currentPage,
+    int? totalPages,
+    SlideshowDirection? direction,
+    List<int>? randomSequence,
+    int? randomIndex,
+  }) {
+    return SlideshowRunning(
+      currentPage: currentPage ?? this.currentPage,
+      totalPages: totalPages ?? this.totalPages,
+      direction: direction ?? this.direction,
+      randomSequence: randomSequence ?? this.randomSequence,
+      randomIndex: randomIndex ?? this.randomIndex,
+    );
+  }
+
+  SlideshowRunning _withUpdatedTotalPages(int newTotalPages) {
+    final adjusted = SlideshowState._adjustForTotalPagesChange(
+      oldTotalPages: totalPages,
+      newTotalPages: newTotalPages,
+      currentPage: currentPage,
+      randomSequence: randomSequence,
+      randomIndex: randomIndex,
+    );
+
+    return copyWith(
+      currentPage: adjusted.currentPage,
+      totalPages: newTotalPages,
+      randomSequence: adjusted.randomSequence,
+      randomIndex: adjusted.randomIndex,
+    );
+  }
 }
 
 final class SlideshowPaused extends SlideshowState {
@@ -161,6 +244,37 @@ final class SlideshowPaused extends SlideshowState {
       direction: direction,
       randomSequence: randomSequence,
       randomIndex: randomIndex,
+    );
+  }
+
+  SlideshowPaused copyWith({
+    int? currentPage,
+    int? totalPages,
+    List<int>? randomSequence,
+    int? randomIndex,
+  }) {
+    return SlideshowPaused(
+      currentPage: currentPage ?? this.currentPage,
+      totalPages: totalPages ?? this.totalPages,
+      randomSequence: randomSequence ?? this.randomSequence,
+      randomIndex: randomIndex ?? this.randomIndex,
+    );
+  }
+
+  SlideshowPaused _withUpdatedTotalPages(int newTotalPages) {
+    final adjusted = SlideshowState._adjustForTotalPagesChange(
+      oldTotalPages: totalPages,
+      newTotalPages: newTotalPages,
+      currentPage: currentPage,
+      randomSequence: randomSequence,
+      randomIndex: randomIndex,
+    );
+
+    return copyWith(
+      currentPage: adjusted.currentPage,
+      totalPages: newTotalPages,
+      randomSequence: adjusted.randomSequence,
+      randomIndex: adjusted.randomIndex,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1174,10 +1174,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -2028,26 +2028,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   timeago:
     dependency: "direct main"
     description:

--- a/test/slideshow_test.dart
+++ b/test/slideshow_test.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 
 // Package imports:
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // Project imports:
@@ -98,6 +99,7 @@ void main() {
     SlideshowController createController({
       SlideshowOptions options = const SlideshowOptions(),
       SlideshowAdvanceCallback? onBeforeAdvance,
+      int totalPages = 3
     }) {
       return SlideshowController(
         onNavigateToPage: (page, skip) {
@@ -108,6 +110,7 @@ void main() {
         options: options,
         onBeforeAdvance: onBeforeAdvance,
         createTimer: timerController.createTimer,
+        totalPagesNotifier: ValueNotifier(totalPages)
       );
     }
 
@@ -115,7 +118,7 @@ void main() {
       test('stops advancing when stopped', () async {
         final controller = createController();
 
-        controller.start(0, 5);
+        controller.start(0);
         await timerController.triggerNext();
         controller.stop();
         timerController.clearHistory();
@@ -127,7 +130,7 @@ void main() {
       test('resume restarts timer and sets active state', () {
         final controller = createController();
 
-        controller.start(0, 5);
+        controller.start(0);
         controller.stop();
 
         expect(controller.isRunning, false);
@@ -144,14 +147,14 @@ void main() {
           ),
         );
 
-        controller.start(0, 3);
+        controller.start(0);
         await timerController.triggerNext();
         await timerController.triggerNext();
 
         controller.stop();
         navigatedPages.clear();
 
-        controller.start(0, 3);
+        controller.start(0);
         await timerController.triggerNext();
         await timerController.triggerNext();
 
@@ -178,9 +181,9 @@ void main() {
 
       for (final c in forwardNavigationCases) {
         test(c.description, () async {
-          final controller = createController();
+          final controller = createController(totalPages: c.totalPages);
 
-          controller.start(c.startPage, c.totalPages);
+          controller.start(c.startPage);
           await timerController.triggerNext();
 
           expect(navigatedPages, c.expected);
@@ -207,10 +210,12 @@ void main() {
           final controller = createController(
             options: const SlideshowOptions(
               direction: SlideshowDirection.backward,
+              
             ),
+            totalPages: c.totalPages
           );
 
-          controller.start(c.startPage, c.totalPages);
+          controller.start(c.startPage);
           await timerController.triggerNext();
 
           expect(navigatedPages, c.expected);
@@ -226,7 +231,7 @@ void main() {
             ),
           );
 
-          controller.start(0, 3);
+          controller.start(0);
 
           final seenPages = <int>{};
           for (var i = 0; i < 3; i++) {
@@ -271,7 +276,7 @@ void main() {
             ),
           );
 
-          controller.start(0, 5);
+          controller.start(0);
           await timerController.triggerNext();
 
           expect(navigatedSkipFlags.first, c.expected);
@@ -289,7 +294,7 @@ void main() {
           },
         );
 
-        controller.start(0, 3);
+        controller.start(0);
         await timerController.triggerNext();
         await timerController.triggerNext();
 


### PR DESCRIPTION
Goal: allow background fetching of more pages of posts while scrolling through 

Solution: To avoid redesigning the entire way posts are managed, i've implemented a "lazy list" class, `DetailsPostsListing<T> extends ListBase<T>` which replaces the simple `List<T extends Post>` which was passed around before. It still supports storing a simple List for cases where a controller isn't available (i haven't tried very hard).

To make the UI work with dynamic updates, i introduced multiple new `ValueListenableBuilder` listening to the `DetailsPostsListing.dynlen` which is a `ValueNotifier<int>` for changes in the length of available items.

Notes:
- The new classes currently live in `lib/core/posts/details/src/routes/details_route_context.dart` as the main class, `DetailsPostsListing<T>` is a field on the `DetailsRouteContext` class.
- DetailsPostsListing internally stores `List<dynamic>`/`PostGridController<dynamic>` to avoid having to specify 2 generics. The output type T is able to be changed by `listingMap((i) => i as SpecificPost)` to replicate the `controller.items.map((i) => i as SpecificPost).toList()` behaviour which was used in a few places.
- `DetailsPostsListing` delegates the handling of infinite/pagination modes to a corresponding `_ListingStrategy`
- `_InfiniteStrategy` is pretty straightforward: fetch new posts when near the end, and update the length
- `_PaginatedStrategy` essentially implements a kind of "infinite scrolling" on top of the underlying paginated nature of `PostGridController`. For this it stores all seen posts, both forwards and backwards, adding to them whenever approaching one of the edges of the loaded state. Because this means that it has to add posts *before* the current ones, i calls out to `PostDetailsPageViewController` to jump to the correct post (previous post index + new items length) so the UI visually stays on the post the user was looking at while extending to the left.
- `SlideshowController` has gotten a `_handleTotalPagesChanged` which calls a new method `withUpdatedTotalPages` on `SlideshowState`. This is implemented by updating the `totalPages`, the currentPage if necessary (fewer posts), and the `randomSequence` if its used. The `randomSequence` is kept as-is, with the new pages posts added on top. That means in effect it will randomize each page internally but it won't randomize across pages.

Status:
- [x] background loading
  - [x] when infinite scrolling selected
    - [x] for post details
    - [x] for slideshow
  - [x] when paginated is selected
    - [x] for post details
    - [x] for slideshow